### PR TITLE
Corrige eventos por que não aparecem na visualização por mapa

### DIFF
--- a/src/core/Repositories/Event.php
+++ b/src/core/Repositories/Event.php
@@ -341,9 +341,9 @@ class Event extends \MapasCulturais\Repository{
         $conn = $this->_em->getConnection();
 
         if($params){
-            $rs = $conn->fetchAssociative($sql, $params);
+            $rs = $conn->fetchAllAssociative($sql, $params);
         } else {
-            $rs = $conn->fetchAssociative($sql);
+            $rs = $conn->fetchAllAssociative($sql);
         }
 
         $rs = $rs ?: [];


### PR DESCRIPTION
## Contexto 

O usuário não consegue visualizar no mapa os eventos.

## Descrição 

Mais detalhes em redemapas/mapas#140

## Modificações na base de código 

Foi trocada a forma como os dados são requisitados do banco de dados e com isso passar a responder da maneira esperada no frontend.

Como essa alteração modifica uma classe basica de acesso, é importante testar outras funcionalidades que requisitam os dados através desse método.

## Modificações fora da base de código 

Nenhuma realizada     

## Informações adicionais 

É possível realizar os testes em https://experimente.mapas.tec.br
