### PR TITLE
Adiciona modal com mensagem sucesso em denuncia e contato

### DIFF
--- a/src/modules/Components/components/complaint-suggestion/script.js
+++ b/src/modules/Components/components/complaint-suggestion/script.js
@@ -26,6 +26,7 @@ app.component('complaint-suggestion', {
         let sitekey = $MAPAS.complaintSuggestionConfig.recaptcha.sitekey;
         let definitions = $MAPAS.notification_type;
         let recaptchaResponse = '';
+        let sendSuccess = false;
         let formData = {
             name: $MAPAS.complaintSuggestionConfig.senderName,
             email: $MAPAS.complaintSuggestionConfig.email,
@@ -40,7 +41,7 @@ app.component('complaint-suggestion', {
             suggestion: definitions.suggestion_type.config.options,
         }
 
-        return { definitions, options, typeMessage, sitekey, recaptchaResponse, formData, isAuth }
+        return { definitions, options, typeMessage, sitekey, sendSuccess, recaptchaResponse, formData, isAuth }
     },
 
     methods: {
@@ -74,6 +75,7 @@ app.component('complaint-suggestion', {
 
             await api.POST(url, objt).then(res => res.json()).then(data => {
                 this.messages.success(this.text('Dados enviados com suscesso'));
+                this.sendSuccess = true;
             });
         },
         async verifyCaptcha(response) {
@@ -115,6 +117,7 @@ app.component('complaint-suggestion', {
                 anonimous: false,
                 copy: false,
             }
+            this.sendSuccess = false;
         }
     },
 });

--- a/src/modules/Components/components/complaint-suggestion/template.php
+++ b/src/modules/Components/components/complaint-suggestion/template.php
@@ -13,52 +13,63 @@ $this->import("
 <div class="complaint-suggestion col-12">
     <div class="complaint-sugestion__complaint">
         <mc-modal title="<?= i::__('Denúncia') ?>" classes="complaint-sugestion__modal">
+            <template v-if="!sendSuccess" #default>
+                <div class="complaint-suggestion__modal-content">
+                    <div class="complaint-suggestion__input-group">
+                        <div class="field">
+                            <label>
+                                <input type="checkbox" v-model="formData.anonimous" @click="formData.copy = false;"><?= i::__('Enviar a denúncia de forma anônima') ?>
+                            </label>
+                        </div>
+                    </div>
 
-            <div class="complaint-suggestion__modal-content">
-                <div class="complaint-suggestion__input-group">
+                    <div v-if="!formData.anonimous" class="field">
+                        <label><?= i::__('Nome') ?></label>
+                        <input type="text" v-model="formData.name">
+                    </div>
+
+                    <div v-if="!formData.anonimous || formData.copy" class="field">
+                        <label><?= i::__('E-mail') ?></label>
+                        <input type="text" v-model="formData.email">
+                    </div>
+
                     <div class="field">
-                        <label>
-                            <input type="checkbox" v-model="formData.anonimous" @click="formData.copy = false;"><?= i::__('Enviar a denúncia de forma anônima') ?>
-                        </label>
+                        <label><?= i::__('Tipo') ?></label>
+                        <select v-model="formData.type">
+                            <option value=""><?= i::__('Selecione') ?></option>
+                            <option v-for="(item,index) in options.complaint" v-bind:value="item">{{item}}</option>
+                        </select>
+                    </div>
+
+                    <div class="field">
+                        <label><?= i::__('Mensagem') ?></label>
+                        <textarea v-model="formData.message"></textarea>
+                    </div>
+
+                    <div class="complaint-suggestion__input-group">
+                        <div :class="['field', {'disabled':formData.anonimous}]">
+                            <label>
+                                <input type="checkbox" :disabled="formData.anonimous" v-model="formData.copy"><?= i::__('Receber copia da mensagem') ?>
+                            </label>
+                        </div>
                     </div>
                 </div>
+            </template>
 
-                <div v-if="!formData.anonimous" class="field">
-                    <label><?= i::__('Nome') ?></label>
-                    <input type="text" v-model="formData.name">
+            <template v-if="sendSuccess" #default>
+                <div class="complaint-suggestion__modal-content">
+                    <label class="bold"><?= i::__('Denúncia enviada com sucesso') ?></label>
+                    <label><?php i::_e('Sua mensagem foi enviada para a equipe responsável. Agradecemos a contribuição.'); ?> </label>
                 </div>
+            </template>
 
-                <div v-if="!formData.anonimous || formData.copy" class="field">
-                    <label><?= i::__('E-mail') ?></label>
-                    <input type="text" v-model="formData.email">
-                </div>
-
-                <div class="field">
-                    <label><?= i::__('Tipo') ?></label>
-                    <select v-model="formData.type">
-                        <option value=""><?= i::__('Selecione') ?></option>
-                        <option v-for="(item,index) in options.complaint" v-bind:value="item">{{item}}</option>
-                    </select>
-                </div>
-
-                <div class="field">
-                    <label><?= i::__('Mensagem') ?></label>
-                    <textarea v-model="formData.message"></textarea>
-                </div>
-
-                <div class="complaint-suggestion__input-group">
-                    <div :class="['field', {'disabled':formData.anonimous}]">
-                        <label>
-                            <input type="checkbox" :disabled="formData.anonimous" v-model="formData.copy"><?= i::__('Receber copia da mensagem') ?>
-                        </label>
-                    </div>
-                </div>
-            </div>
-            
-            <template #actions="modal">
+            <template v-if="!sendSuccess"  #actions="modal">
                 <VueRecaptcha v-if="sitekey" :sitekey="sitekey" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="complaint-suggestion__recaptcha"></VueRecaptcha>
                 <button class="button button--primary" @click="send(modal)"><?= i::__('Enviar Denúncia') ?></button>
                 <button class="button button--text button--text-del" @click="modal.close()"><?= i::__('cancelar') ?></button>
+            </template>
+            <template  v-if="sendSuccess"  #actions="modal">
+               <button class="button button--primary" @click="modal.close()"><?= i::__('Fechar') ?></button>
             </template>
 
             <template #button="modal">
@@ -69,59 +80,70 @@ $this->import("
 
     <div class="complaint-suggestion__suggestion">
         <mc-modal title="<?= i::__('Contato') ?>" classes="complaint-sugestion__modal">
+            <template v-if="!sendSuccess" #default>
+                <div class="complaint-suggestion__modal-content">
 
-            <div class="complaint-suggestion__modal-content">
+                    <div class="complaint-suggestion__input-group">
+                        <div class="field">
+                            <label>
+                                <input type="checkbox" v-model="formData.anonimous" @click="formData.copy = false;"><?= i::__('Enviar a mensagem de forma anônima') ?>
+                            </label>
+                        </div>
+                    </div>
 
-                <div class="complaint-suggestion__input-group">
+                    <div v-if="!formData.anonimous" class="field">
+                        <label><?= i::__('Nome') ?></label>
+                        <input type="text" v-model="formData.name">
+                    </div>
+
+                    <div v-if="!formData.anonimous || formData.copy" class="field">
+                        <label><?= i::__('E-mail') ?></label>
+                        <input type="text" v-model="formData.email">
+                    </div>
+
                     <div class="field">
-                        <label>
-                            <input type="checkbox" v-model="formData.anonimous" @click="formData.copy = false;"><?= i::__('Enviar a mensagem de forma anônima') ?>
-                        </label>
+                        <label><?= i::__('Tipo') ?></label>
+                        <select v-model="formData.type">
+                            <option value=""><?= i::__('Selecione') ?></option>
+                            <option v-for="(item,index) in options.suggestion" v-bind:value="item">{{item}}</option>
+                        </select>
                     </div>
-                </div>
 
-                <div v-if="!formData.anonimous" class="field">
-                    <label><?= i::__('Nome') ?></label>
-                    <input type="text" v-model="formData.name">
-                </div>
-
-                <div v-if="!formData.anonimous || formData.copy" class="field">
-                    <label><?= i::__('E-mail') ?></label>
-                    <input type="text" v-model="formData.email">
-                </div>
-
-                <div class="field">
-                    <label><?= i::__('Tipo') ?></label>
-                    <select v-model="formData.type">
-                        <option value=""><?= i::__('Selecione') ?></option>
-                        <option v-for="(item,index) in options.suggestion" v-bind:value="item">{{item}}</option>
-                    </select>
-                </div>
-
-                <div class="field">
-                    <label><?= i::__('Mensagem:') ?></label>
-                    <textarea v-model="formData.message"></textarea>
-                </div>
-
-                <div class="complaint-suggestion__input-group">
                     <div class="field">
-                        <label>
-                            <input type="checkbox" v-model="formData.only_owner"><?= i::__('Enviar somente para o responsável') ?>
-                        </label>
+                        <label><?= i::__('Mensagem:') ?></label>
+                        <textarea v-model="formData.message"></textarea>
                     </div>
 
-                    <div :class="['field', {'disabled':formData.anonimous}]">
-                        <label>
-                            <input type="checkbox" :disabled="formData.anonimous" v-model="formData.copy"><?= i::__('Receber copia da mensagem') ?>
-                        </label>
+                    <div class="complaint-suggestion__input-group">
+                        <div class="field">
+                            <label>
+                                <input type="checkbox" v-model="formData.only_owner"><?= i::__('Enviar somente para o responsável') ?>
+                            </label>
+                        </div>
+
+                        <div :class="['field', {'disabled':formData.anonimous}]">
+                            <label>
+                                <input type="checkbox" :disabled="formData.anonimous" v-model="formData.copy"><?= i::__('Receber copia da mensagem') ?>
+                            </label>
+                        </div>
                     </div>
                 </div>
-            </div>
+            </template>
+            <template v-if="sendSuccess" #default>
+                <div class="complaint-suggestion__modal-content">
+                    <label class="bold"><?= i::__('Mensagem enviada com sucesso') ?></label>
+                    <label v-if="formData.anonimous"><?php i::_e('Sua mensagem foi enviada.'); ?> </label>
+                    <label v-else><?php i::_e('Sua mensagem foi enviada para '); ?> {{ formData.name }} </label>
+                </div>
+            </template>
 
-            <template #actions="modal">
+            <template v-if="!sendSuccess" #actions="modal">
                 <VueRecaptcha v-if="sitekey" :sitekey="sitekey" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="complaint-suggestion__recaptcha"></VueRecaptcha>
                 <button class="button button--primary" @click="send(modal)"><?= i::__('Enviar Mensagem') ?></button>
                 <button class="button button--text button--text-del" @click="modal.close()"><?= i::__('Cancelar') ?></button>
+            </template>
+            <template  v-if="sendSuccess"  #actions="modal">
+               <button class="button button--primary" @click="modal.close()"><?= i::__('Fechar') ?></button>
             </template>
 
             <template #button="modal">


### PR DESCRIPTION
# Contexto
Mensagem de envio de contato ou denuncia passa muito rapido.
# Descrição
Na aba de um evento, ao fazer uma denuncia ou adicionar um contato a mensagem de sucesso ficava por pouco tempo e poderia passar despercebida então foi sugerido apresentarmos uma modal de sucesso, com texto específico para cada caso.
# Modificações na base de código
Nenhuma
# Modificações fora da base
Foram alterados o template e o js do "components/complaint-suggestion" para adicionar o novo modal.
# Informações adicionais
[Link da issue](https://github.com/RedeMapas/mapas/pull/5)
