### PR TITLE
feat: implementa ação de duplicação da entidade oportunidade

### DIFF
--- a/src/core/Controllers/Opportunity.php
+++ b/src/core/Controllers/Opportunity.php
@@ -32,6 +32,7 @@ class Opportunity extends EntityController {
         Traits\ControllerArchive,
         Traits\ControllerAPI,
         Traits\ControllerAPINested,
+        Traits\EntityOpportunityDuplicator,
         Traits\ControllerEntityActions {
             Traits\ControllerEntityActions::PATCH_single as _PATCH_single;
         }

--- a/src/core/Traits/EntityOpportunityDuplicator.php
+++ b/src/core/Traits/EntityOpportunityDuplicator.php
@@ -1,0 +1,223 @@
+<?php
+namespace MapasCulturais\Traits;
+
+use MapasCulturais\App;
+use MapasCulturais\Entity;
+
+trait EntityOpportunityDuplicator {
+
+    private $entityOpportunity;
+    private $entityNewOpportunity;
+
+    function ALL_duplicate(){
+        $app = App::i();
+
+        $this->requireAuthentication();
+        $this->entityOpportunity = $this->requestedEntity;
+        $this->entityNewOpportunity = $this->cloneOpportunity();
+
+
+        $this->duplicateEvaluationMethods();
+        $this->duplicatePhases();
+        $this->duplicateMetadata();
+        $this->duplicateRegistrationFieldsAndFiles();
+        $this->duplicateMetalist();
+        $this->duplicateFiles();
+        $this->duplicateAgentRelations();
+        $this->duplicateSealsRelations();
+
+        $this->entityNewOpportunity->save(true);
+       
+        if($this->isAjax()){
+            $this->json($this->entityOpportunity);
+        }else{
+            $app->redirect($app->request->getReferer());
+        }
+    }
+
+    private function cloneOpportunity()
+    {
+        $app = App::i();
+
+        $this->entityNewOpportunity = clone $this->entityOpportunity;
+
+        $dateTime = new \DateTime();
+        $now = $dateTime->format('d-m-Y H:i:s');
+        $name = $this->entityOpportunity->name;
+        $this->entityNewOpportunity->name = "$name  - [Cópia][$now]";
+        $this->entityNewOpportunity->status = Entity::STATUS_DRAFT;
+        $app->em->persist($this->entityNewOpportunity);
+        $app->em->flush();
+
+        $this->entityNewOpportunity->registrationCategories = $this->entityOpportunity->registrationCategories;
+        $this->entityNewOpportunity->registrationProponentTypes = $this->entityOpportunity->registrationProponentTypes;
+        $this->entityNewOpportunity->registrationRanges = $this->entityOpportunity->registrationRanges;
+        $this->entityNewOpportunity->save(true);
+
+        return $this->entityNewOpportunity;
+    }
+
+    private function duplicateEvaluationMethods() : void
+    {
+        $app = App::i();
+
+        // duplica o método de avaliação para a oportunidade primária
+        $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
+            'opportunity' => $this->entityOpportunity
+        ]);
+        foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
+            $newMethodConfiguration = clone $evaluationMethodConfiguration;
+            $newMethodConfiguration->setOpportunity($this->entityNewOpportunity);
+            $newMethodConfiguration->save(true);
+
+            // duplica os metadados das configurações do modelo de avaliação
+            foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
+                $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
+                $newMethodConfiguration->save(true);
+            }
+
+            foreach ($evaluationMethodConfiguration->getAgentRelations() as $agentRelation_) {
+                $agentRelation = clone $agentRelation_;
+                $agentRelation->owner = $newMethodConfiguration;
+                $agentRelation->save(true);
+            }
+        }
+    }
+
+    private function duplicatePhases() : void
+    {
+        $app = App::i();
+
+        $phases = $app->repo('Opportunity')->findBy([
+            'parent' => $this->entityOpportunity
+        ]);
+        foreach ($phases as $phase) {
+            if (!$phase->getMetadata('isLastPhase')) {
+                $newPhase = clone $phase;
+                $newPhase->setParent($this->entityNewOpportunity);
+
+                // duplica os metadados das fases
+                foreach ($phase->getMetadata() as $metadataKey => $metadataValue) {
+                    if (!is_null($metadataValue) && $metadataValue != '') {
+                        $newPhase->setMetadata($metadataKey, $metadataValue);
+                        $newPhase->save(true);
+                    }
+                }
+
+                $newPhase->save(true);
+
+                // duplica os modelos de avaliações das fases
+                $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
+                    'opportunity' => $phase
+                ]);
+
+                foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
+                    $newMethodConfiguration = clone $evaluationMethodConfiguration;
+                    $newMethodConfiguration->setOpportunity($newPhase);
+                    $newMethodConfiguration->save(true);
+
+                    // duplica os metadados das configurações do modelo de avaliação para a fase
+                    foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
+                        $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
+                        $newMethodConfiguration->save(true);
+                    }
+
+                    foreach ($evaluationMethodConfiguration->getAgentRelations() as $agentRelation_) {
+                        $agentRelation = clone $agentRelation_;
+                        $agentRelation->owner = $newMethodConfiguration;
+                        $agentRelation->save(true);
+                    }
+                }
+            }
+
+            if ($phase->getMetadata('isLastPhase')) {
+                $publishDate = $phase->publishTimestamp;
+            }
+        }
+
+        if (isset($publishDate)) {
+            $phases = $app->repo('Opportunity')->findBy([
+                'parent' => $this->entityNewOpportunity
+            ]);
+    
+            foreach ($phases as $phase) {
+                if ($phase->getMetadata('isLastPhase')) {
+                    $phase->setPublishTimestamp($publishDate);
+                    $phase->save(true);
+                }
+            }
+        }       
+    }
+
+    private function duplicateMetadata() : void
+    {
+        foreach ($this->entityOpportunity->getMetadata() as $metadataKey => $metadataValue) {
+            if (!is_null($metadataValue) && $metadataValue != '') {
+                $this->entityNewOpportunity->setMetadata($metadataKey, $metadataValue);
+            }
+        }
+
+        $this->entityNewOpportunity->setTerms(['area' => $this->entityOpportunity->terms['area']]);
+        $this->entityNewOpportunity->setTerms(['tag' => $this->entityOpportunity->terms['tag']]);
+        $this->entityNewOpportunity->saveTerms();
+    }
+   
+    private function duplicateRegistrationFieldsAndFiles() : void
+    {
+        foreach ($this->entityOpportunity->getRegistrationFieldConfigurations() as $registrationFieldConfiguration) {
+            $fieldConfiguration = clone $registrationFieldConfiguration;
+            $fieldConfiguration->setOwnerId($this->entityNewOpportunity->id);
+            $fieldConfiguration->save(true);
+        }
+
+        foreach ($this->entityOpportunity->getRegistrationFileConfigurations() as $registrationFileConfiguration) {
+            $fileConfiguration = clone $registrationFileConfiguration;
+            $fileConfiguration->setOwnerId($this->entityNewOpportunity->id);
+            $fileConfiguration->save(true);
+        }
+
+    }
+
+    private function duplicateMetalist() : void
+    {
+        foreach ($this->entityOpportunity->getMetaLists() as $metaList_) {
+            foreach ($metaList_ as $metaList__) {
+                $metalist = clone $metaList__;
+                $metalist->setOwner($this->entityNewOpportunity);
+            
+                $metalist->save(true);
+            }
+        }
+    }
+
+    private function duplicateFiles() : void
+    {
+        $app = App::i();
+
+        $opportunityFiles = $app->repo('OpportunityFile')->findBy([
+            'owner' => $this->entityOpportunity
+        ]);
+
+        foreach ($opportunityFiles as $opportunityFile) {
+            $newMethodOpportunityFile = clone $opportunityFile;
+            $newMethodOpportunityFile->owner = $this->entityNewOpportunity;
+            $newMethodOpportunityFile->save(true);
+        }
+    }
+
+    private function duplicateAgentRelations() : void
+    {
+        foreach ($this->entityOpportunity->getAgentRelations() as $agentRelation_) {
+            $agentRelation = clone $agentRelation_;
+            $agentRelation->owner = $this->entityNewOpportunity;
+            $agentRelation->save(true);
+        }
+    }
+
+    private function duplicateSealsRelations() : void
+    {
+        foreach ($this->entityOpportunity->getSealRelations() as $sealRelation) {
+            $this->entityNewOpportunity->createSealRelation($sealRelation->seal, true, true);
+        }
+    }
+}

--- a/src/modules/Components/assets/js/components-base/API.js
+++ b/src/modules/Components/assets/js/components-base/API.js
@@ -240,6 +240,12 @@ class API {
         }
     }
 
+    async duplicateEntity(entity) {
+        if (entity[this.$PK]) {
+            return this.POST(entity.getUrl('duplicate'));   
+        }
+    }
+
     async unpublishEntity(entity) {
         if (entity[this.$PK]) {
             return this.POST(entity.getUrl('unpublish'));

--- a/src/modules/Components/assets/js/components-base/Entity.js
+++ b/src/modules/Components/assets/js/components-base/Entity.js
@@ -517,6 +517,22 @@ class Entity {
         }
     }
 
+    async duplicate(removeFromLists) {
+        this.__processing = this.text('duplicando');
+
+        try {
+            const res = await this.API.duplicateEntity(this);
+            return this.doPromise(res, (entity) => {
+                this.sendMessage(this.text('entidade duplicada'));
+                this.populate(entity);
+                
+                window.open('/minhas-oportunidades/#draft', '_blank').focus();
+            });
+        } catch (error) {
+            return this.doCatch(error);
+        }
+    }
+
     async archive(removeFromLists) {
         this.__processing = this.text('arquivando');
 

--- a/src/modules/Components/components/mc-entity/texts.php
+++ b/src/modules/Components/components/mc-entity/texts.php
@@ -9,6 +9,7 @@ return [
     'criando' => i::__('Criando'),
     'salvando' => i::__('Salvando a entidade'),
     'publicando' => i::__('Publicando a entidade'),
+    'duplicando' => i::__('Duplicando a entidade'),
     'arquivando' => i::__('Arquivando a entidade'),
     'excluindo' => i::__('Excluindo a entidade'),
     'excluindo definitivamente' => i::__('Excluindo a entidade definitivamente'),

--- a/src/modules/Entities/components/entity-actions/template.php
+++ b/src/modules/Entities/components/entity-actions/template.php
@@ -44,6 +44,19 @@ $this->import('
                         <?php i::_e('Você está certo que deseja excluir?') ?>
                     </template>
                 </mc-confirm-button>
+                <mc-confirm-button v-if="entity.currentUserPermissions?.modify && entity.status != -2 && entity.__objectType == 'opportunity' && entity.isModel != 1" @confirm="entity.duplicate()" no="Cancelar" yes="Continuar">
+                    <template #button="modal">
+                        <button @click="modal.open()" class="button button--icon button--sm">
+                            <?php i::_e("Duplicar oportunidade") ?>
+                        </button>
+                    </template>
+                    <template #message="message">
+                        <h4><b><?php i::_e('Duplicar oportunidade'); ?></b></h4>
+                        <br>
+                        <p><?php i::_e('Todas as configurações atuais da oportunidade, incluindo o vínculo<br> com a entidade associada e os campos de formulário criados, serão<br> duplicadas.') ?></p>
+                        <p><?php i::_e('Deseja continuar?') ?></p>
+                    </template>
+                </mc-confirm-button> 
                 <?php $this->applyTemplateHook('entity-actions--primary', 'end') ?>
             </div>
             <?php $this->applyTemplateHook('entity-actions--leftGroupBtn', 'after'); ?>

--- a/src/modules/Panel/components/panel--entity-actions/script.js
+++ b/src/modules/Panel/components/panel--entity-actions/script.js
@@ -45,6 +45,12 @@ app.component('panel--entity-actions', {
             const promise = entity.archive();
             this.$emit('archived', {entity, modal, promise});
         },
+
+        duplicateEntity(modal) {
+            const entity = this.entity;
+            const promise = entity.duplicate();
+            this.$emit('duplicate', {entity, modal, promise});
+        },
         
         deleteEntity(modal) {
             const entity = this.entity;


### PR DESCRIPTION
## Descrição

Implementa regra de duplicação de oportunidade, fazendo com que se crie uma nova oportunidade baseado em uma oportunidade já existente, com todos os dados entre eles os da fases.

## Validação

Acessar a oportunidade e no footer de ações clicar no botão "Salvar modelo" em seguida deve abrir um modal de confirmação e ser redirecionado para a lista de oportunidade em rascunho com a nova oportunidade criada.

![Gravaodetelade30-07-2024134440-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/4945b035-587f-4b8a-a7a4-db9d335e92c6)


## Issues relacionadas

https://github.com/RedeMapas/mapas/issues/325

