### PR TITLE
Pr dev minc/tags não clicáveis com mesmo tratamento visual de links

### DIFF
--- a/src/modules/Components/components/entity-card/template.php
+++ b/src/modules/Components/components/entity-card/template.php
@@ -92,19 +92,19 @@ $this->import('
 		<div class="entity-card__content--terms">
 			<div v-if="areas" class="entity-card__content--terms-area">
 				<label v-if="entity.__objectType === 'opportunity'" class="area__title">
-					<?php i::_e('Áreas de interesse:') ?> ({{entity.terms.area.length}}):
+					<?php i::_e('Áreas de interesse') ?> ({{entity.terms.area.length}}):
 				</label>
 				<label v-if="entity.__objectType === 'agent' || entity.__objectType === 'space'" class="area__title">
-					<?php i::_e('Áreas de atuação:') ?> ({{entity.terms.area.length}}):
+					<?php i::_e('Áreas de atuação') ?> ({{entity.terms.area.length}}):
 				</label>
-				<p :class="['terms', entity.__objectType+'__color']"> {{areas}} </p>
+				<p :class="['terms']"> {{areas}} </p>
 			</div>
 
 			<div v-if="tags" class="entity-card__content--terms-tag">
 				<label class="tag__title">
-					<?php i::_e('Tags:') ?> ({{entity.terms.tag.length}}):
+					<?php i::_e('Tags') ?> ({{entity.terms.tag.length}}):
 				</label>
-				<p :class="['terms', entity.__objectType+'__color']"> {{tags}} </p>
+				<p :class="'terms'"> {{tags}} </p>
 			</div>
 
 			<div v-if="linguagens" class="entity-card__content--terms-linguagem">

--- a/src/modules/Components/components/occurrence-card/template.php
+++ b/src/modules/Components/components/occurrence-card/template.php
@@ -60,17 +60,17 @@ $this->import('
             </div>
         </div>
         <div class="entity-card__content--terms">
-            <div v-if="tags" class="entity-card__content--terms-tag">
+            <div v-if="tags" class="-tag">
                 <label class="tag__title">
-                    <?php i::_e('Tags:') ?> ({{event.terms.tag.length}}):
+                    <?php i::_e('Tags') ?> ({{event.terms.tag.length}}):
                 </label>
-                <p :class="['terms', 'event__color']"> {{tags}} </p>
+                <p :class="'terms'"> {{tags}} </p>
             </div>
             <div v-if="linguagens" class="entity-card__content--terms-linguagem">
                 <label class="linguagem__title">
-                    <?php i::_e('linguagens:') ?> ({{event.terms.linguagem.length}}):
+                    <?php i::_e('linguagens') ?> ({{event.terms.linguagem.length}}):
                 </label>
-                <p :class="['terms', 'event__color']"> {{linguagens}} </p>
+                <p :class="'terms'"> {{linguagens}} </p>
             </div>
         </div>
     </div>

--- a/src/modules/Entities/components/entity-map/template.php
+++ b/src/modules/Entities/components/entity-map/template.php
@@ -11,7 +11,7 @@ $this->import('
 ?>
 
 <?php $this->applyTemplateHook('entity-map','before'); ?>
-<mc-map :center="entity.location" v-if="entity.endereco">
+<mc-map v-if="entity.endereco" :center="entity.location">
     <mc-map-marker :entity="entity" :draggable="editable" @moved="change($event)"></mc-map-marker>
 </mc-map>
 <?php $this->applyTemplateHook('entity-map','after'); ?>

--- a/src/modules/Entities/components/entity-map/template.php
+++ b/src/modules/Entities/components/entity-map/template.php
@@ -11,7 +11,7 @@ $this->import('
 ?>
 
 <?php $this->applyTemplateHook('entity-map','before'); ?>
-<mc-map :center="entity.location">
+<mc-map v-if="entity.endereco" :center="entity.location">
     <mc-map-marker :entity="entity" :draggable="editable" @moved="change($event)"></mc-map-marker>
 </mc-map>
 <?php $this->applyTemplateHook('entity-map','after'); ?>

--- a/src/modules/Entities/components/entity-map/template.php
+++ b/src/modules/Entities/components/entity-map/template.php
@@ -11,7 +11,7 @@ $this->import('
 ?>
 
 <?php $this->applyTemplateHook('entity-map','before'); ?>
-<mc-map v-if="entity.endereco" :center="entity.location">
+<mc-map :center="entity.location" v-if="entity.endereco">
     <mc-map-marker :entity="entity" :draggable="editable" @moved="change($event)"></mc-map-marker>
 </mc-map>
 <?php $this->applyTemplateHook('entity-map','after'); ?>

--- a/src/modules/Entities/components/entity-terms/script.js
+++ b/src/modules/Entities/components/entity-terms/script.js
@@ -115,14 +115,29 @@ app.component('entity-terms', {
 
 
         addTerm(term) {
-            if (this.entity.terms[this.taxonomy].indexOf(term) < 0) {
-                this.entity.terms[this.taxonomy].push(term);
+            if(this.spaceCheck(term)) {
+                if (this.entity.terms[this.taxonomy].indexOf(term) < 0) {
+                    this.entity.terms[this.taxonomy].push(term);
+                    
+                }
+    
+                if (this.terms.indexOf(term) < 0) {
+                   this.terms.push(term);
+                }
             }
+        },
 
-            if (this.terms.indexOf(term) < 0) {
-                this.terms.push(term);
+        spaceCheck(term) {
+            if(this.taxonomy == "tag") {
+                let tam = term.length;
+                for (let i = 0; i < tam; i++) {
+                    if (term[i] != " ") {
+                        return true;
+                    }
+                }
+                return false;
             }
-           
+            return true;
         },
 
         taxomyExists() {

--- a/src/modules/Entities/components/entity-terms/template.php
+++ b/src/modules/Entities/components/entity-terms/template.php
@@ -16,7 +16,6 @@ $this->import('
 <div v-if="taxomyExists() && (editable || entity.terms?.[taxonomy].length > 0)" :class="['entity-terms', classes, error]">
     <div class="entity-terms__header">
         <mc-title tag="h4" :short-length="0" size="medium" class="bold">{{title ?? taxonomy}}</mc-title>
-        <span v-if="required && !hideRequired" class="entity-terms__required">*<?=i::__('obrigatório');?></span>
     </div>
  
     <mc-popover v-if="allowInsert && editable" openside="down-right"  @open="loadTerms()" :title="popoverTitle">

--- a/src/modules/Entities/views/project/single.php
+++ b/src/modules/Entities/views/project/single.php
@@ -82,7 +82,7 @@ if($children_id ){
 
                                 <div v-if="entity.emailPublico" class="additional-info__item">
                                     <p class="additional-info__item__title"><?php i::_e("email:"); ?></p>
-                                    <p class="additional-info__item__content">{{entity.emailPublico}}</p>
+                                    <p>{{entity.emailPublico}}</p>
                                 </div>
                             </div>
                             <div v-if="entity.longDescription!=null" class="col-12">


### PR DESCRIPTION
# Contexto
Na tela de eventos havia alguns problemas de ux como destaque de "hyperlinks" onde não deveria, formatação errada quando há mais de uma linguagem e email em caixa alta
# Descrição
Mais detalhes em [issue 135](https://github.com/RedeMapas/mapas/issues/135)
# Modificação na base do código
Nenhuma
# Modificação fora da base de código
hove modificações no "components/entity-card", "components/occurrence-card","components/entity-map", "components/entity-terms","components/entity-terms" e "Entities/views/project"
Em todos foram feitos pequenas modificações que corrigem erros de interface
