### PR TITLE
Adiciona método intermediario para criação de uma nova ocorrência

### DIFF
--- a/src/modules/Entities/components/create-occurrence/script.js
+++ b/src/modules/Entities/components/create-occurrence/script.js
@@ -185,6 +185,13 @@ app.component('create-occurrence', {
             this.price = this.moneyMask(floatNum);
         },
 
+        // Salva modificações no evento e cria a ocorrência
+        saveDataState(modal){
+            this.entity.save();
+
+            this.create(modal);
+        },
+
         // Criação da ocorrência
         create(modal) {
             this.newOccurrence.eventId = this.entity.id;

--- a/src/modules/Entities/components/create-occurrence/template.php
+++ b/src/modules/Entities/components/create-occurrence/template.php
@@ -276,7 +276,7 @@ $this->import('
         <div class="desktop">
             <div class="button-group">
                 <button class="button button--text" @click="cancel(modal)"><?php i::_e('Cancelar')?></button>
-                <button class="button button--primary" @click="create(modal)"><?php i::_e('Inserir ocorrência')?></button>
+                <button class="button button--primary" :entity="entity" @click="saveDataState(modal)"><?php i::_e('Inserir ocorrência')?></button>
             </div>
         </div>
     </template>


### PR DESCRIPTION
# Contexto
Ao adicionar uma nova ocorrencia na pagina de edição de eventos, outras modificações são perdidas.
# Descrição
Mais detalhes em [https://github.com/RedeMapas/mapas/issues/131](Issue 131)
# Modificações na base de código
nenhuma
# Modificações fora da base de código
foram modificadas o script.js e o template do "Entities/components/create-occurrence"  que salva o estados anterior das alterações feitas ao criar uma nova occorência, assim o que foi modificado não se perde