### PR TITLE
Evolucao 5321 componentizacao captcha

### DIFF
--- a/config/captcha.php
+++ b/config/captcha.php
@@ -1,8 +1,5 @@
 <?php
 return [
-    'app.recaptcha.key' => env("GOOGLE_RECAPTCHA_SITEKEY", null),
-    'app.recaptcha.secret' => env("GOOGLE_RECAPTCHA_SECRET", null),
-
     /**
      * Configuração para implementação de captcha seguindo um novo padrão de configuração
      * 
@@ -10,20 +7,19 @@ return [
      * - Esse padrão de configuração permite a implementação de outros provedores de captcha, como por exemplo o Cloudflare Turnstile
      */
     'captcha' => [
-        'provider' => 'cloudflare',
-        // 'provider' => 'google',
+        'provider' => env('CAPTCHA_PROVIDER', 'google'),
         'providers' => [
             'google' => [
                 'url' => 'https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit',
                 'verify' => 'https://www.google.com/recaptcha/api/siteverify',
-                'key' => env('GOOGLE_RECAPTCHA_SITEKEY', null),
-                'secret' => env('GOOGLE_RECAPTCHA_SECRET', null)
+                'key' => env('CAPTCHA_SITEKEY', env('GOOGLE_RECAPTCHA_SITEKEY', null)),
+                'secret' => env('CAPTCHA_SECRET', env('GOOGLE_RECAPTCHA_SECRET', null))
             ],
             'cloudflare' => [
                 'url' => 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit',
                 'verify' => 'https://challenges.cloudflare.com/turnstile/v0/siteverify',
-                'key' => env('TURNSTILE_RECAPTCHA_SITEKEY', null),
-                'secret' => env('TURNSTILE_RECAPTCHA_SECRET', null)
+                'key' => env('CAPTCHA_SITEKEY', null),
+                'secret' => env('CAPTCHA_SECRET', null)
             ]
         ]
     ]

--- a/config/captcha.php
+++ b/config/captcha.php
@@ -10,13 +10,20 @@ return [
      * - Esse padrão de configuração permite a implementação de outros provedores de captcha, como por exemplo o Cloudflare Turnstile
      */
     'captcha' => [
-        'provider' => 'google',
+        'provider' => 'cloudflare',
+        // 'provider' => 'google',
         'providers' => [
             'google' => [
-                'url' => 'https://www.google.com/recaptcha/api.js',
+                'url' => 'https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit',
                 'verify' => 'https://www.google.com/recaptcha/api/siteverify',
                 'key' => env('GOOGLE_RECAPTCHA_SITEKEY', null),
                 'secret' => env('GOOGLE_RECAPTCHA_SECRET', null)
+            ],
+            'cloudflare' => [
+                'url' => 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit',
+                'verify' => 'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+                'key' => env('TURNSTILE_RECAPTCHA_SITEKEY', null),
+                'secret' => env('TURNSTILE_RECAPTCHA_SECRET', null)
             ]
         ]
     ]

--- a/config/captcha.php
+++ b/config/captcha.php
@@ -1,5 +1,23 @@
 <?php
-return [    
+return [
     'app.recaptcha.key' => env("GOOGLE_RECAPTCHA_SITEKEY", null),
     'app.recaptcha.secret' => env("GOOGLE_RECAPTCHA_SECRET", null),
+
+    /**
+     * Configuração para implementação de captcha seguindo um novo padrão de configuração
+     * 
+     * - O exemplo abaixo segue o padrão de configuração para o Google Recaptcha atualmente utilizado
+     * - Esse padrão de configuração permite a implementação de outros provedores de captcha, como por exemplo o Cloudflare Turnstile
+     */
+    'captcha' => [
+        'provider' => 'google',
+        'providers' => [
+            'google' => [
+                'url' => 'https://www.google.com/recaptcha/api.js',
+                'verify' => 'https://www.google.com/recaptcha/api/siteverify',
+                'key' => env('GOOGLE_RECAPTCHA_SITEKEY', null),
+                'secret' => env('GOOGLE_RECAPTCHA_SECRET', null)
+            ]
+        ]
+    ]
 ];

--- a/src/core/App.php
+++ b/src/core/App.php
@@ -794,6 +794,9 @@ class App {
             $theme_instance = new $theme_class($this->config['themes.assetManager'], $this->subsite);
         } else {
             $theme_class = $this->config['themes.active'] . '\Theme';
+
+            // dd($theme_class);
+
             $theme_instance = new $theme_class($this->config['themes.assetManager']);
         }
 
@@ -3786,34 +3789,11 @@ class App {
     /** 
      * ============ MÉTODOS DE VERIFICAÇÃO DO CAPTCHA ============ 
      */
-    function verifyRecaptcha2(string $token = '')
+    function verifyCaptcha(string $token = '')
     {
         // If we don't receive the token, there is no reason to advance to the verification
         if (empty($token)) {
             return false;
-        }
-
-        // If the captcha configuration does not exist, it means that captcha has not been implemented
-        if (!isset($this->config['captcha']) && !isset($this->config['app.recaptcha.key'])) {
-            return true;
-        }
-
-        // If the new captcha configuration does not exist, but the old one does, we will use the old one
-        if (!isset($this->config['captcha']) && isset($this->config['app.recaptcha.key'])) {
-            $this->config['captcha'] = [
-                'provider' => 'google',
-                'providers' => [
-                    'google' => [
-                        'secret' => $this->config['app.recaptcha.secret'],
-                        'verify' => 'https://www.google.com/recaptcha/api/siteverify'
-                    ]
-                ]
-            ];
-        }
-
-        // Is necessary to check because the provider can be defined in the new configuration
-        if (!isset($this->config['captcha']['provider'])) {
-            $this->config['captcha']['provider'] = 'google';
         }
 
         // In this point we are sure that the provider was defined

--- a/src/modules/CompliantSuggestion/Module.php
+++ b/src/modules/CompliantSuggestion/Module.php
@@ -137,9 +137,14 @@ class Module extends \MapasCulturais\Module {
 
         $app->hook('POST(<<agent|space|event|project|opportunity>>.sendComplaintMessage)', function() use ($plugin) {
             $app = App::i();
-            
-             //Verificando recaptcha v2
-            if (!$plugin->verifyRecaptcha2()) {
+
+            // Se não recebemos o token, não há motivo para avançar para a verificação
+            if (!isset($_POST["g-recaptcha-response"]) || empty($_POST["g-recaptcha-response"])) {
+                throw new \Exception(\MapasCulturais\i::__('Recaptcha não selecionado ou inválido, tente novamente.'));
+            }
+
+            //Verificando recaptcha v2
+            if (!$app->verifyRecaptcha2($_POST['g-recaptcha-response'])) {
                 throw new \Exception(\MapasCulturais\i::__('Recaptcha não selecionado ou inválido, tente novamente.'));
             }
 
@@ -211,9 +216,14 @@ class Module extends \MapasCulturais\Module {
         $app->hook('POST(<<agent|space|event|project|opportunity>>.sendSuggestionMessage)', function() use ($plugin) {
             $app = App::i();
 
+            // Se não recebemos o token, não há motivo para avançar para a verificação
+            if (!isset($_POST["g-recaptcha-response"]) || empty($_POST["g-recaptcha-response"])) {
+                throw new \Exception(\MapasCulturais\i::__('Recaptcha não selecionado ou inválido, tente novamente.'));
+            }
+
             //Verificando recaptcha v2
-            if (!$plugin->verifyRecaptcha2()) {
-                throw new \Exception( \MapasCulturais\i::__('Recaptcha não selecionado ou inválido, tente novamente.') );
+            if (!$app->verifyRecaptcha2($_POST['g-recaptcha-response'])) {
+                throw new \Exception(\MapasCulturais\i::__('Recaptcha não selecionado ou inválido, tente novamente.'));
             }
 
             $entity = $app->repo($this->entityClassName)->find($this->data['entityId']);
@@ -312,47 +322,6 @@ class Module extends \MapasCulturais\Module {
     }
 
     public function register() { }
-
-    public function verificarToken($token, $secretkey)
-    {
-        $url = "https://www.google.com/recaptcha/api/siteverify";
-
-        $data = [
-            "secret" => $secretkey,
-            "response" => $token,
-        ];
-
-        $options = [
-            "http" => [
-                "header" => "Content-type: application/x-www-form-urlencoded\r\n",
-                "method" => "POST",
-                "content" => http_build_query($data), 
-            ],
-        ];
-
-        $context = stream_context_create($options);
-
-        $result = file_get_contents($url, false, $context);
-
-        if ($result === false) {
-            return false;
-        }
-
-        $result = json_decode($result);
-
-        return $result->success;
-    }
-
-    public function verifyRecaptcha2() {
-        $app = App::i();
-        $config = $app->_config;
-    
-        if (!isset($app->_config['app.recaptcha.key'])) return true;
-        if (!isset($_POST["g-recaptcha-response"]) || empty($_POST["g-recaptcha-response"])) return false;
-
-        $token = $_POST["g-recaptcha-response"];
-        return $this->verificarToken($token, $app->_config['app.recaptcha.secret']);
-    }
 
     public function addConfigToJs()
     {

--- a/src/modules/CompliantSuggestion/Module.php
+++ b/src/modules/CompliantSuggestion/Module.php
@@ -88,7 +88,6 @@ class Module extends \MapasCulturais\Module {
         $app = App::i();
         $config = $this->_config;
 
-        $app->view->enqueueScript('app', 'recaptcha', 'https://www.google.com/recaptcha/api.js');
 
         $plugin = $this;
 

--- a/src/modules/Components/components/complaint-suggestion/init.php
+++ b/src/modules/Components/components/complaint-suggestion/init.php
@@ -19,9 +19,6 @@ $config = [
     'isAuth' => $isAUth,
     'senderName' => $isAUth ? $app->user->profile->name : "",
     'senderEmail' => $isAUth ? $ownerEmail : "",
-    'recaptcha' => [
-        'sitekey' =>  $app->_config['app.recaptcha.key'],
-    ]
 ];
 
 $this->jsObject['complaintSuggestionConfig'] = $config;

--- a/src/modules/Components/components/complaint-suggestion/script.js
+++ b/src/modules/Components/components/complaint-suggestion/script.js
@@ -23,7 +23,7 @@ app.component('complaint-suggestion', {
     data() {
         let isAuth = $MAPAS.complaintSuggestionConfig.isAuth;
         let typeMessage = "";
-        let sitekey = $MAPAS.complaintSuggestionConfig.recaptcha.sitekey;
+        let hasCaptcha = false;
         let definitions = $MAPAS.notification_type;
         let recaptchaResponse = '';
         let formData = {
@@ -40,7 +40,7 @@ app.component('complaint-suggestion', {
             suggestion: definitions.suggestion_type.config.options,
         }
 
-        return { definitions, options, typeMessage, sitekey, recaptchaResponse, formData, isAuth }
+        return { definitions, options, typeMessage, hasCaptcha, recaptchaResponse, formData, isAuth }
     },
 
     methods: {
@@ -52,7 +52,8 @@ app.component('complaint-suggestion', {
             let objt = this.formData;
             objt.entityId = this.entity.id;
             
-            if(this.sitekey){
+            // A flag será usada para identificar se o componente filho implementa o Captcha
+            if (this.hasCaptcha) {
                 objt['g-recaptcha-response'] = this.recaptchaResponse;
             }
 
@@ -80,13 +81,14 @@ app.component('complaint-suggestion', {
             this.recaptchaResponse = response;
         },
         expiredCaptcha() {
+            this.hasCaptcha = true;
             this.recaptchaResponse = '';
         },
         validade(objt) {
             let result = null;
             let ignore = ["copy", "anonimous", "only_owner"];
 
-            if(!this.sitekey){
+            if(!this.hasCaptcha){
                 ignore.push("g-recaptcha-response");
             }
 

--- a/src/modules/Components/components/complaint-suggestion/script.js
+++ b/src/modules/Components/components/complaint-suggestion/script.js
@@ -67,14 +67,14 @@ app.component('complaint-suggestion', {
                 if (error == "g-recaptcha-response") {
                     mess = this.text('Recaptcha inválida');
                 } else {
-                    mess = this.text('Todos os campos são obrigatorio');
+                    mess = this.text('Todos os campos são obrigatórios');
                 }
                 this.messages.error(mess);
                 return;
             }
 
             await api.POST(url, objt).then(res => res.json()).then(data => {
-                this.messages.success(this.text('Dados enviados com suscesso'));
+                this.messages.success(this.text('Dados enviados com sucesso'));
             });
         },
         async verifyCaptcha(response) {

--- a/src/modules/Components/components/complaint-suggestion/template.php
+++ b/src/modules/Components/components/complaint-suggestion/template.php
@@ -123,7 +123,7 @@ $this->import("
 
             <template #actions="modal">
                 <!-- Componente responsável por renderizar o captcha [Google | Turnstile] -->
-                <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha"></mc-captcha>
+                <mc-captcha class="complaint-suggestion__recaptcha" @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha"></mc-captcha>
 
                 <button class="button button--primary" @click="send(modal)"><?= i::__('Enviar Mensagem') ?></button>
                 <button class="button button--text button--text-del" @click="modal.close()"><?= i::__('Cancelar') ?></button>

--- a/src/modules/Components/components/complaint-suggestion/template.php
+++ b/src/modules/Components/components/complaint-suggestion/template.php
@@ -8,6 +8,7 @@ use MapasCulturais\i;
 
 $this->import(" 
     mc-modal
+    mc-captcha
 ");
 ?>
 <div class="complaint-suggestion col-12">
@@ -56,7 +57,9 @@ $this->import("
             </div>
             
             <template #actions="modal">
-                <VueRecaptcha v-if="sitekey" :sitekey="sitekey" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="complaint-suggestion__recaptcha"></VueRecaptcha>
+                <!-- Componente responsável por renderizar o captcha [Google | Turnstile] -->
+                <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha"></mc-captcha>
+
                 <button class="button button--primary" @click="send(modal)"><?= i::__('Enviar Denúncia') ?></button>
                 <button class="button button--text button--text-del" @click="modal.close()"><?= i::__('cancelar') ?></button>
             </template>

--- a/src/modules/Components/components/complaint-suggestion/template.php
+++ b/src/modules/Components/components/complaint-suggestion/template.php
@@ -58,7 +58,7 @@ $this->import("
             
             <template #actions="modal">
                 <!-- Componente responsável por renderizar o captcha [Google | Turnstile] -->
-                <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha"></mc-captcha>
+                <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha" class="col-12"></mc-captcha>
 
                 <button class="button button--primary" @click="send(modal)"><?= i::__('Enviar Denúncia') ?></button>
                 <button class="button button--text button--text-del" @click="modal.close()"><?= i::__('cancelar') ?></button>

--- a/src/modules/Components/components/complaint-suggestion/template.php
+++ b/src/modules/Components/components/complaint-suggestion/template.php
@@ -122,7 +122,9 @@ $this->import("
             </div>
 
             <template #actions="modal">
-                <VueRecaptcha v-if="sitekey" :sitekey="sitekey" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="complaint-suggestion__recaptcha"></VueRecaptcha>
+                <!-- Componente responsável por renderizar o captcha [Google | Turnstile] -->
+                <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha"></mc-captcha>
+
                 <button class="button button--primary" @click="send(modal)"><?= i::__('Enviar Mensagem') ?></button>
                 <button class="button button--text button--text-del" @click="modal.close()"><?= i::__('Cancelar') ?></button>
             </template>

--- a/src/modules/Components/components/complaint-suggestion/template.php
+++ b/src/modules/Components/components/complaint-suggestion/template.php
@@ -57,7 +57,7 @@ $this->import("
             </div>
             
             <template #actions="modal">
-                <!-- Componente responsável por renderizar o captcha [Google | Turnstile] -->
+                <!-- Componente responsável por renderizar o CAPTCHA -->
                 <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha" class="col-12"></mc-captcha>
 
                 <button class="button button--primary" @click="send(modal)"><?= i::__('Enviar Denúncia') ?></button>
@@ -122,7 +122,7 @@ $this->import("
             </div>
 
             <template #actions="modal">
-                <!-- Componente responsável por renderizar o captcha [Google | Turnstile] -->
+                <!-- Componente responsável por renderizar o CAPTCHA -->
                 <mc-captcha class="complaint-suggestion__recaptcha" @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha"></mc-captcha>
 
                 <button class="button button--primary" @click="send(modal)"><?= i::__('Enviar Mensagem') ?></button>

--- a/src/modules/Components/components/complaint-suggestion/texts.php
+++ b/src/modules/Components/components/complaint-suggestion/texts.php
@@ -4,6 +4,6 @@ use MapasCulturais\i;
 
 return [
     'Recaptcha inválida' => i::__('Recaptcha inválida'),
-    'Todos os campos são obrigatorio' => i::__('Todos os campos são obrigatório'),
+    'Todos os campos são obrigatórios' => i::__('Todos os campos são obrigatórios'),
     'Dados enviados com sucesso' => i::__('Dados enviados com sucesso'),
 ];

--- a/src/modules/Components/components/complaint-suggestion/texts.php
+++ b/src/modules/Components/components/complaint-suggestion/texts.php
@@ -4,6 +4,6 @@ use MapasCulturais\i;
 
 return [
     'Recaptcha inválida' => i::__('Recaptcha inválida'),
-    'Todos os campos são obrigatorio' => i::__('Todos os campos são obrigatorio'),
-    'Dados enviados com suscesso' => i::__('Dados enviados com suscesso'),
+    'Todos os campos são obrigatorio' => i::__('Todos os campos são obrigatório'),
+    'Dados enviados com sucesso' => i::__('Dados enviados com sucesso'),
 ];

--- a/src/modules/Components/components/mc-captcha/init.php
+++ b/src/modules/Components/components/mc-captcha/init.php
@@ -1,19 +1,8 @@
 <?php
 
 // Se a configuração de captcha não existir, significa que o captcha não foi implementado
-if (!isset($app->config['captcha']) && !isset($app->_config['app.recaptcha.key'])) {
+if (!isset($app->config['captcha'])) {
     return;
-}
-
-// Se não houver configuração nova de captcha, mas houver configuração antiga, vamos utilizar a configuração antiga
-if (!isset($app->_config['captcha']) && isset($app->_config['app.recaptcha.key']) && isset($app->_config['app.recaptcha.secret'])) {
-    return $this->jsObject['mcCaptchaConfig'] = [
-        'captcha' => [
-            'provider' => 'google',
-            'key' => $app->_config['app.recaptcha.key'],
-            'secret' => $app->_config['app.recaptcha.secret']
-        ]
-    ];
 }
 
 if (!isset($app->_config['captcha']['providers'])) {

--- a/src/modules/Components/components/mc-captcha/init.php
+++ b/src/modules/Components/components/mc-captcha/init.php
@@ -1,5 +1,25 @@
 <?php
 
+// Se a configuração de captcha não existir, significa que o captcha não foi implementado
+if (!isset($app->config['captcha']) && !isset($app->_config['app.recaptcha.key'])) {
+    return;
+}
+
+// Se não houver configuração nova de captcha, mas houver configuração antiga, vamos utilizar a configuração antiga
+if (!isset($app->_config['captcha']) && isset($app->_config['app.recaptcha.key']) && isset($app->_config['app.recaptcha.secret'])) {
+    return $this->jsObject['mcCaptchaConfig'] = [
+        'captcha' => [
+            'provider' => 'google',
+            'key' => $app->_config['app.recaptcha.key'],
+            'secret' => $app->_config['app.recaptcha.secret']
+        ]
+    ];
+}
+
+if (!isset($app->_config['captcha']['providers'])) {
+    throw new \Exception('Configuração de captcha inválida');
+}
+
 $provider = $app->_config['captcha']['provider'];
 $captcha = $app->_config['captcha']['providers'][$provider];
 

--- a/src/modules/Components/components/mc-captcha/init.php
+++ b/src/modules/Components/components/mc-captcha/init.php
@@ -1,0 +1,17 @@
+<?php
+
+$provider = $app->_config['captcha']['provider'];
+$captcha = $app->_config['captcha']['providers'][$provider];
+
+$key = $captcha['key'];
+$secret = $captcha['secret'];
+
+$config = [
+    'captcha' => [
+        'provider' => $provider,
+        'key' => $key,
+        'secret' => $secret
+    ]
+];
+
+$this->jsObject['mcCaptchaConfig'] = $config;

--- a/src/modules/Components/components/mc-captcha/init.php
+++ b/src/modules/Components/components/mc-captcha/init.php
@@ -23,6 +23,9 @@ if (!isset($app->_config['captcha']['providers'])) {
 $provider = $app->_config['captcha']['provider'];
 $captcha = $app->_config['captcha']['providers'][$provider];
 
+// Importando a biblioteca do captcha
+$app->view->enqueueScript('components', 'captcha', $captcha['url']);
+
 $key = $captcha['key'];
 $secret = $captcha['secret'];
 

--- a/src/modules/Components/components/mc-captcha/script.js
+++ b/src/modules/Components/components/mc-captcha/script.js
@@ -1,0 +1,48 @@
+app.component('mc-captcha', {
+    template: $TEMPLATES['mc-captcha'],
+
+    components: {
+        VueRecaptcha
+    },
+
+    props: {
+        config: {
+            type: String,
+            required: true
+        }
+    },
+
+    setup() {
+        const text = Utils.getTexts('mc-captcha');
+
+        return { text }
+    },
+
+    data() {
+        const config = $MAPAS.mcCaptchaConfig;
+
+        return {
+            provider: config.captcha.provider,
+            key: config.captcha.key,
+            recaptchaResponse: ''
+        }
+    },
+
+    mounted() {
+        //
+    },
+
+    computed: {
+        // 
+    },
+
+    methods: {
+        async verifyCaptcha(response) {
+            this.$emit('captcha-verified', response);
+        },
+
+        expiredCaptcha() {
+            this.$emit('captcha-expired');
+        },
+    }
+});

--- a/src/modules/Components/components/mc-captcha/script.js
+++ b/src/modules/Components/components/mc-captcha/script.js
@@ -22,8 +22,8 @@ app.component('mc-captcha', {
         const config = $MAPAS.mcCaptchaConfig;
 
         return {
-            provider: config.captcha.provider,
-            key: config.captcha.key,
+            provider: config?.captcha?.provider,
+            key: config?.captcha.key,
             recaptchaResponse: ''
         }
     },

--- a/src/modules/Components/components/mc-captcha/script.js
+++ b/src/modules/Components/components/mc-captcha/script.js
@@ -29,9 +29,13 @@ app.component('mc-captcha', {
     },
 
     mounted() {
-        //
-    },
+        if (this.provider === 'cloudflare') {
+            window.turnstile.ready(() => this.onloadTurnstileCallback());
 
+            window.verifyCaptcha = this.verifyCaptcha;
+            window.expiredCaptcha = this.expiredCaptcha;
+        };
+    },
     computed: {
         // 
     },
@@ -44,5 +48,18 @@ app.component('mc-captcha', {
         expiredCaptcha() {
             this.$emit('captcha-expired');
         },
+
+        onloadTurnstileCallback() {
+            const self = this;
+            turnstile.render("#container-cloudflare-turnstile", {
+                sitekey: self.key,
+                callback: function (token) {
+                    self.verifyCaptcha(token);
+                },
+                "expired-callback": function () {
+                    self.expiredCaptcha();
+                }
+            });
+        }
     }
 });

--- a/src/modules/Components/components/mc-captcha/template.php
+++ b/src/modules/Components/components/mc-captcha/template.php
@@ -4,7 +4,11 @@ use MapasCulturais\i;
 
 ?>
 
-<div>
+<div style="display: flex; flex-direction: column; align-items: center;">
     <!-- Google Recaptcha -->
     <VueRecaptcha v-if="provider == 'google'" :sitekey="key" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="g-recaptcha"></VueRecaptcha>
+
+
+    <!-- Cloudflare Turnstile -->
+    <div v-if="provider == 'cloudflare'" id="container-cloudflare-turnstile"></div>
 </div>

--- a/src/modules/Components/components/mc-captcha/template.php
+++ b/src/modules/Components/components/mc-captcha/template.php
@@ -1,0 +1,10 @@
+<?php
+
+use MapasCulturais\i;
+
+?>
+
+<div>
+    <!-- Google Recaptcha -->
+    <VueRecaptcha v-if="provider == 'google'" :sitekey="key" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="g-recaptcha"></VueRecaptcha>
+</div>

--- a/src/modules/Components/components/mc-captcha/texts.php
+++ b/src/modules/Components/components/mc-captcha/texts.php
@@ -1,0 +1,7 @@
+<?php
+
+use MapasCulturais\i;
+
+return [
+    //
+];

--- a/src/translations/empty.po
+++ b/src/translations/empty.po
@@ -4498,11 +4498,11 @@ msgid "Recaptcha inválida"
 msgstr ""
 
 #: modules/Components/components/complaint-suggestion/texts.php:7
-msgid "Todos os campos são obrigatorio"
+msgid "Todos os campos são obrigatórios"
 msgstr ""
 
 #: modules/Components/components/complaint-suggestion/texts.php:8
-msgid "Dados enviados com suscesso"
+msgid "Dados enviados com sucesso"
 msgstr ""
 
 #: modules/Components/components/entity-card/template.php:27

--- a/src/translations/es_AR.po
+++ b/src/translations/es_AR.po
@@ -5401,11 +5401,11 @@ msgid "Recaptcha inválida"
 msgstr "Recaptcha no válido"
 
 #: src/modules/Components/components/complaint-suggestion/texts.php:7
-msgid "Todos os campos são obrigatorio"
+msgid "Todos os campos são obrigatórios"
 msgstr "Todos los campos son obligatorios"
 
 #: src/modules/Components/components/complaint-suggestion/texts.php:8
-msgid "Dados enviados com suscesso"
+msgid "Dados enviados com sucesso"
 msgstr "Datos enviados con éxito"
 
 #: src/modules/Components/components/entity-card/template.php:27
@@ -21736,10 +21736,10 @@ msgstr "Acerca del sitio web"
 #~ msgid "Recaptcha inválida"
 #~ msgstr "Recaptcha no válido"
 
-#~ msgid "Todos os campos são obrigatorio"
+#~ msgid "Todos os campos são obrigatórios"
 #~ msgstr "Todos los campos son obligatorios"
 
-#~ msgid "Dados enviados com suscesso"
+#~ msgid "Dados enviados com sucesso"
 #~ msgstr "Datos enviados con éxito"
 
 #~ msgid "ONDE: "


### PR DESCRIPTION
# Cenário
Centralizar todo o carregamento do captcha em um componente para que seja possível configurar N providers, de forma que torne mais flexível o uso e implementação de Captcha no Mapa Da Cultura.

## Pontos importantes
Foi tomado cuidado para que essa centralização não afete aqueles que desejam manter às configurações anteriores.

## Telas afetadas:
- Login (MultipleLocalAuth) -> Esta implementação será feita no repositório devido
- Tela de denúncias

## Abordagem seguida
- Implementação de um novo padrão de configurações
- criação de um componente específico para tratar captcha (mc-captcha)
- Para diminuir ao máximo os impactos dessa nova implementação, a abordagem adota foi que o novo componente tem a responsabilidade de informar o componente pai (ex: complaintSugestion) dos seguintes eventos:
  - Expiração de token
  - Verificação de token
- Migração e implementação de verificação de token diretamente no CORE do Mapa Da Cultura
