### PR TITLE
Correcao 6620 duplicar oportunidade

### DIFF
--- a/src/db-updates.php
+++ b/src/db-updates.php
@@ -2610,5 +2610,16 @@ $$
                FROM etnias;
         ");
     },
+    "Removendo os campos e anexos de formulário erroneamente duplicados pela funcionalidade 'Duplicar Oportunidade'" => function() {
+        __try("DELETE FROM registration_field_configuration rfc
+                     USING registration_step rs
+                     WHERE rs.id = rfc.step_id
+                       AND rs.opportunity_id != rfc.opportunity_id;");
+
+        __try("DELETE FROM registration_file_configuration rfc
+                     USING registration_step rs
+                     WHERE rs.id = rfc.step_id
+                       AND rs.opportunity_id != rfc.opportunity_id;");
+    }
   
 ] + $updates ;   

--- a/src/modules/Opportunities/Module.php
+++ b/src/modules/Opportunities/Module.php
@@ -46,6 +46,10 @@ class Module extends \MapasCulturais\Module{
         });
 
         $app->hook('entity(Opportunity).insert:after', function() {
+            if ($this->registrationSteps && count($this->registrationSteps) > 0) {
+                return;
+            }
+
             $step = new RegistrationStep();
             $step->name = '';
             $step->opportunity = $this;


### PR DESCRIPTION
### Contexto  

A funcionalidade de duplicação de oportunidade apresenta dois erros que comprometem a correta replicação dos formulários e suas etapas.  

-------
### Primeiro erro: `step_id` não atualizado  
A coluna `step_id` não estava sendo atualizada para as novas etapas pertencentes ao novo formulário, fazendo com que os campos duplicados continuassem referenciando as etapas do formulário original.  

#### Consequências:  
- O formulário duplicado continha campos associados a ele, mas que não estavam visíveis.  
- As inscrições apresentavam erro, pois, caso houvesse um campo ou anexo obrigatório, esses elementos não eram exibidos para o usuário, impedindo o preenchimento.  

-------
### Segundo erro: criação de fase inicial adicional  
O processo de duplicação estava gerando uma fase inicial extra, resultando em inconsistências na estrutura do formulário duplicado.  

#### Consequências:  
- A fase inicial adicional poderia causar redundância na sequência de etapas.  
- O fluxo de preenchimento do formulário poderia ser afetado, impactando a experiência do usuário.  

-------
### Abordagens para correção  
Para corrigir os erros identificados, serão adotadas as seguintes abordagens:  

1. **Correção do apontamento para a coluna `step_id`**  
   - Garantir que os `RegistrationFieldConfiguration` duplicados referenciem corretamente os novos `RegistrationStep`, evitando vínculos com a oportunidade original.  

2. **Ajuste no hook `entity(Opportunity).insert:after`**  
   - Modificar a lógica do hook para evitar a criação automática de uma fase inicial caso a oportunidade duplicada já possua `step` no formulário.  
