### PR TITLE
Correcao 6638 lista inscritos

### DIFF
--- a/src/modules/Opportunities/components/opportunity-registrations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/script.js
@@ -307,7 +307,7 @@ app.component('opportunity-registrations-table', {
                 itens.push({ text: __('status', 'opportunity-registrations-table'), value: "status", width: '250px', stickyRight: true})
             }
 
-            let type = this.phase.evaluationMethodConfiguration.type.id;
+            let type = this.phase.evaluationMethodConfiguration?.type.id || '';
             let phases = $MAPAS.opportunityPhases;
             let hasEvaluationMethodTechnical = false;
 

--- a/src/modules/Opportunities/components/opportunity-registrations-table/script.js
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/script.js
@@ -317,9 +317,8 @@ app.component('opportunity-registrations-table', {
                     break;
                 }
 
-                let type = phase.evaluationMethodConfiguration ? phase.evaluationMethodConfiguration.type.id : phase.type.id;
-
-                if(type == "technical"){
+                let phaseType = phase.evaluationMethodConfiguration ? phase.evaluationMethodConfiguration.type.id : phase.type.id;
+                if(phaseType == "technical"){
                     hasEvaluationMethodTechnical = true;
                     break;
                 }


### PR DESCRIPTION
### Contexto  
O acesso à propriedade `evaluationMethodConfiguration` estava incompleto, pois há casos em que `evaluationMethodConfiguration` pode não estar definido e vai estourar erro.  

### Erro  
`TypeError: Cannot read properties of undefined (reading 'type')`  

### Solução  
Adicionei o operador *optional chaining* para evitar erro da aplicação.  
![image](https://github.com/user-attachments/assets/c65f45d7-f0dc-4a0c-b0bb-c10d5b4e12ca)


### Melhoria  
Observei a variável `type` dentro do `for`. Por pertencer a um escopo diferente (interno do `for`), tomei a liberdade de mudar a sua assinatura para evitar possíveis confusões durante a leitura do código.
![image](https://github.com/user-attachments/assets/e167e161-efc3-4277-a086-7da895cff3e2)

