### PR TITLE
Fix/upd recaptcha

### DIFF
--- a/src/modules/CompliantSuggestion/Module.php
+++ b/src/modules/CompliantSuggestion/Module.php
@@ -143,7 +143,7 @@ class Module extends \MapasCulturais\Module {
             }
 
             //Verificando recaptcha v2
-            if (!$app->verifyRecaptcha2($_POST['g-recaptcha-response'])) {
+            if (!$app->verifyCaptcha($_POST['g-recaptcha-response'])) {
                 throw new \Exception(\MapasCulturais\i::__('Recaptcha não selecionado ou inválido, tente novamente.'));
             }
 
@@ -221,7 +221,7 @@ class Module extends \MapasCulturais\Module {
             }
 
             //Verificando recaptcha v2
-            if (!$app->verifyRecaptcha2($_POST['g-recaptcha-response'])) {
+            if (!$app->verifyCaptcha($_POST['g-recaptcha-response'])) {
                 throw new \Exception(\MapasCulturais\i::__('Recaptcha não selecionado ou inválido, tente novamente.'));
             }
 

--- a/src/modules/Components/components/complaint-suggestion/script.js
+++ b/src/modules/Components/components/complaint-suggestion/script.js
@@ -43,7 +43,7 @@ app.component('complaint-suggestion', {
             suggestion: definitions.suggestion_type.config.options,
         }
 
-        return { definitions, options, typeMessage, sitekey, sendSuccess, recaptchaResponse, formData, isAuth }
+        return { definitions, options, typeMessage, hasCaptcha, sendSuccess, recaptchaResponse, formData, isAuth }
     },
 
     methods: {

--- a/src/modules/Components/components/complaint-suggestion/template.php
+++ b/src/modules/Components/components/complaint-suggestion/template.php
@@ -65,7 +65,9 @@ $this->import("
             </template>
 
             <template v-if="!sendSuccess"  #actions="modal">
-                <VueRecaptcha v-if="sitekey" :sitekey="sitekey" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="complaint-suggestion__recaptcha"></VueRecaptcha>
+                <!-- Componente responsável por renderizar o CAPTCHA -->
+                <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha" :error="error" class="complaint-suggestion__recaptcha"></mc-captcha>
+
                 <button class="button button--primary" @click="send(modal)"><?= i::__('Enviar Denúncia') ?></button>
                 <button class="button button--text button--text-del" @click="modal.close()"><?= i::__('cancelar') ?></button>
             </template>
@@ -139,7 +141,9 @@ $this->import("
             </template>
 
             <template v-if="!sendSuccess" #actions="modal">
-                <VueRecaptcha v-if="sitekey" :sitekey="sitekey" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="complaint-suggestion__recaptcha"></VueRecaptcha>
+                <!-- Componente responsável por renderizar o CAPTCHA -->
+                <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha" :error="error" class="complaint-suggestion__recaptcha"></mc-captcha>
+
                 <button class="button button--primary" @click="send(modal)"><?= i::__('Enviar Mensagem') ?></button>
                 <button class="button button--text button--text-del" @click="modal.close()"><?= i::__('Cancelar') ?></button>
             </template>


### PR DESCRIPTION
## Cenário

A atualização do CORE do **UPD** substituiu o componente `mc-captcha`, responsável por permitir a escolha entre **Google reCAPTCHA** e **Cloudflare Turnstile**.

O componente base do **Mapa** para captcha espera uma propriedade chamada `sitekey`, porém, na versão do **Mapa do MinC**, isso foi substituído pelo `mc-captcha`.

## Solução

Substituir o componente base de captcha do **Mapa** pelo componente `mc-captcha` do **Mapa MinC**, preservando as implementações feitas no **CORE do UPD**.

## Extra

Foi identificada uma chamada incorreta ao método responsável por verificar a validade do captcha.

**Importante:** esse erro **não** é de responsabilidade da comunidade, ou seja, **não** faz parte da atualização do CORE, mas sim um erro de implementação do **MinC**.
