### PR TITLE
fix: adicionando tratativa para exceções ao salvar arquivo no storage

### DIFF
--- a/src/core/Storage/FileSystem.php
+++ b/src/core/Storage/FileSystem.php
@@ -64,7 +64,10 @@ class FileSystem extends \MapasCulturais\Storage{
                 }
             }
 
-            rename($file->tmpFile['tmp_name'], $filename);
+            /** Add verification to check if the file is really saved in storage */
+            if (!move_uploaded_file($file->tmpFile['tmp_name'], $filename)) {
+                throw new \MapasCulturais\Exceptions\FileUploadError($file->getGroup(), 500);
+            }
             chmod($filename, 0666);
         }else{
             return false;

--- a/src/core/Storage/FileSystem.php
+++ b/src/core/Storage/FileSystem.php
@@ -65,9 +65,14 @@ class FileSystem extends \MapasCulturais\Storage{
             }
 
             /** Add verification to check if the file is really saved in storage */
-            if (!move_uploaded_file($file->tmpFile['tmp_name'], $filename)) {
-                throw new \MapasCulturais\Exceptions\FileUploadError($file->getGroup(), 500);
+            if (is_uploaded_file($file->tmpFile['tmp_name'])) {
+                if (!move_uploaded_file($file->tmpFile['tmp_name'], $filename)) {
+                    throw new \MapasCulturais\Exceptions\FileUploadError($file->getGroup(), 500);
+                }
+            } else {
+                rename($file->tmpFile['tmp_name'], $filename);
             }
+
             chmod($filename, 0666);
         }else{
             return false;

--- a/src/core/Traits/ControllerUploads.php
+++ b/src/core/Traits/ControllerUploads.php
@@ -171,7 +171,13 @@ trait ControllerUploads{
                     $old_file->delete();
             }
 
-            $file->save();
+            /** Add verification to see if the file is really saved in storage */
+            try {
+                $file->save();
+            } catch (\MapasCulturais\Exceptions\FileUploadError $th) {
+                return $this->errorJson([$th->group => $th->message]);
+            }
+
             $file_group = $file->group;
 
             if($upload_group->unique){


### PR DESCRIPTION
## Cenário
Hoje existe uma inconsistência na qual temos mais arquivos mapeados na tabela file, do que realmente arquivos gravados em disco (storage).
Como o Mapa utilizado pelo MinC apresenta um volume consideravelmente grande de acessos, este problema apresenta maior impacto.

Corrige um problema de  **Ausência de Exceção** quando o arquivo não é gravado em disco.

## O problema x implementação
https://github.com/user-attachments/assets/c5abc40a-2816-48f3-b1dd-5aa6342afe97