### PR TITLE
fix: adicionando {status} no retorno da consulta das inscrições recentes

### DIFF
--- a/src/modules/Panel/components/panel--last-registrations/script.js
+++ b/src/modules/Panel/components/panel--last-registrations/script.js
@@ -19,7 +19,7 @@ app.component('panel--last-registrations', {
         const registrationAPI = new API('registration');
         
         const query = this.query;
-        query['@select'] = 'id,number,opportunity.{name,files.avatar,registrationFrom,registrationTo},owner.{name},category,range,proponentType,agentRelations,createTimestamp';
+        query['@select'] = 'id,number,status,opportunity.{name,files.avatar,registrationFrom,registrationTo},owner.{name},category,range,proponentType,agentRelations,createTimestamp';
         query['@order'] = 'updateTimestamp ASC';
         query['@permissions'] = 'view';
         query['status'] = 'GTE(0)';


### PR DESCRIPTION
## Contextualização

Há uma discrepância entre a lista de inscrições exibidas em **minhas inscrições** e **painel de controle**.

## Minhas Inscrições

![minhas inscrições  não enviadas](https://github.com/user-attachments/assets/ec3f35cd-78a3-44aa-a315-57cc8e86a35b)
![minhas inscrições  enviadas](https://github.com/user-attachments/assets/fe91b1c4-bdf8-4caa-afcd-22b6f9e05e34)

## Painel de Controle [Com Erro]
![inscrições recentes  status exibido está errado](https://github.com/user-attachments/assets/261c1cc2-3a38-498e-b2e1-dd9dd890cb30)

## Painel de Controle [Corrigido]
![inscrições recentes  status exibido está correto](https://github.com/user-attachments/assets/592fd8ff-9be7-43c4-a646-40a8cc4a2e28)
