### PR TITLE
Corrigindo reatividade do campo de municípios | Compatibilidade no Safari

### DIFF
--- a/src/modules/Components/components/select-municipio/script.js
+++ b/src/modules/Components/components/select-municipio/script.js
@@ -33,7 +33,8 @@ app.component('select-municipio', {
             this.selectedState = option.value;
             const state = this.ibge[this.selectedState];
 
-            this.cities = state ? state.municipios : [];
+            // Força reatividade do array
+            this.cities = state ? [...state.municipios] : [];
             this.selectedCity = null;
         },
 

--- a/src/modules/Components/components/select-municipio/template.php
+++ b/src/modules/Components/components/select-municipio/template.php
@@ -16,17 +16,13 @@ $this->import('
         <label class="field__title">
             <?= i::__('Estado') ?>
         </label>
-        <mc-select placeholder="<?= i::esc_attr_e("Selecione"); ?>" v-model:default-value="selectedState" @change-option="loadCities($event)" show-filter>
-            <option v-for="state in states" :key="state.sigla" :value="state.sigla">{{state.nome}}</option>
-        </mc-select>
+        <mc-select placeholder="<?= i::esc_attr_e("Selecione"); ?>" v-model:default-value="selectedState" @change-option="loadCities($event)" show-filter :options="states.map(state => ({value: state.sigla, label: state.nome}))"></mc-select>
     </div>
     
     <div v-show="selectedState" class="field col-6">
         <label class="field__title">
             <?=i::__('Município') ?>
         </label>
-        <mc-select :key="'city-select-' + selectedState" placeholder="<?= i::esc_attr_e("Selecione"); ?>" v-model:default-value="selectedCity" @change-option="selectCity($event)" show-filter>
-            <option v-for="city in cities" :key="city.nome" :value="city.nome">{{city.nome}}</option>
-        </mc-select>
+        <mc-select :key="'city-select-' + selectedState" placeholder="<?= i::esc_attr_e("Selecione"); ?>" v-model:default-value="selectedCity" @change-option="selectCity($event)" show-filter :options="cities.map(city => ({value: city.nome, label: city.nome}))"></mc-select>
     </div>
 </div>

--- a/src/modules/Components/components/select-municipio/template.php
+++ b/src/modules/Components/components/select-municipio/template.php
@@ -21,11 +21,11 @@ $this->import('
         </mc-select>
     </div>
     
-    <div v-if="selectedState" class="field col-6">
+    <div v-show="selectedState" class="field col-6">
         <label class="field__title">
             <?=i::__('Município') ?>
         </label>
-        <mc-select placeholder="<?= i::esc_attr_e("Selecione"); ?>" v-model:default-value="selectedCity" @change-option="selectCity($event)" show-filter>
+        <mc-select :key="'city-select-' + selectedState" placeholder="<?= i::esc_attr_e("Selecione"); ?>" v-model:default-value="selectedCity" @change-option="selectCity($event)" show-filter>
             <option v-for="city in cities" :key="city.nome" :value="city.nome">{{city.nome}}</option>
         </mc-select>
     </div>


### PR DESCRIPTION
## Contextualização


Há dois erros ao renderizar o campo select do município:
-  Há erro de referência no elemento DOM que acontece devido à um problema de reatividade: O problema acontece quando selecionamos um município e depois mudamos o estado.
- Há um problema de compatibilidade com o navegador Safari, pois este não renderiza a tag `<option>` que não esteja dentro da tag `<select>`.

## Erro de Reatividade - [Bug]
https://github.com/user-attachments/assets/45cbbecb-a1f2-43ff-8c16-13a5ceeaadfe

##  Erro de Reatividade - [Corrigido]
https://github.com/user-attachments/assets/b9a15ced-d0f5-4904-89dc-042f75bc5c03

--- 

## Erro de Compatibilidade com Navegador Safari - [Bug]

https://github.com/user-attachments/assets/7a8c027d-b820-4b49-a1a4-6534d8fb9f2a



## Erro de Compatibilidade com Navegador Safari - [Corrigido]

Seguem os testes gravados nos navegadores: Safari e Google Chrome

https://github.com/user-attachments/assets/ed79c279-4d78-472f-bf58-38269a241738


https://github.com/user-attachments/assets/f1d10b1d-009f-4370-a31b-0715c30c1248

