### PR TITLE
Corrige erro na consolidação da avaliação que marcava como inabilitada uma organização previamente habilitada.

### DIFF
--- a/src/modules/Entities/components/entity-field/template.php
+++ b/src/modules/Entities/components/entity-field/template.php
@@ -63,9 +63,11 @@ $this->import('
 
             <template v-else-if="is('select')">
                 <template v-if="description.registrationFieldConfiguration?.config?.viewMode === 'radio'">
-                    <label class="input__label input__radioLabel" v-for="(optionLabel, optionValue) in description.options">
-                        <input :checked="isRadioChecked(value, optionValue)" type="radio" :value="optionValue" @input="change($event,true)" @blur="change($event)" :disabled="readonly || disabled"> {{description.options[optionValue]}}
-                    </label>
+                    <div class="field__group">
+                        <label class="input__label input__radioLabel" v-for="(optionLabel, optionValue) in description.options">
+                            <input :checked="isRadioChecked(value, optionValue)" type="radio" :value="optionValue" @input="change($event,true)" @blur="change($event)" :disabled="readonly || disabled"> {{description.options[optionValue]}}
+                        </label>
+                    </div>
                 </template>
 
                 <select v-else :value="value" :id="propId" :name="prop" @input="change($event)" @blur="change($event,true)" :disabled="readonly || disabled">
@@ -74,9 +76,11 @@ $this->import('
             </template>
 
             <template v-else-if="is('radio')">
-                <label class="input__label input__radioLabel" v-for="(optionLabel, optionValue) in description.options">
-                    <input :checked="isRadioChecked(value, optionValue)" type="radio" :value="optionValue" @input="change($event,true)" @blur="change($event)" :disabled="readonly || disabled"> {{description.options[optionValue]}}
-                </label>
+                <div class="field__group">
+                    <label class="input__label input__radioLabel" v-for="(optionLabel, optionValue) in description.options">
+                        <input :checked="isRadioChecked(value, optionValue)" type="radio" :value="optionValue" @input="change($event,true)" @blur="change($event)" :disabled="readonly || disabled"> {{description.options[optionValue]}}
+                    </label>
+                </div>
             </template>
 
             <template v-else-if="is('links')">

--- a/src/modules/EvaluationMethodQualification/components/evaluation-qualification-detail/template.php
+++ b/src/modules/EvaluationMethodQualification/components/evaluation-qualification-detail/template.php
@@ -24,11 +24,11 @@ $this->import('
                 <label>
                     <?= i::__('Resultado: ') ?>
                 </label>
-                <strong v-if="registration.consolidatedResult === 'Habilitado'" class="success__color">
+                <strong v-if="registration.consolidatedResult === 'valid'" class="success__color">
                     <mc-icon name="circle" class="success__color"></mc-icon>{{registration.score}}
                     {{registration.consolidatedResult}}
                 </strong>
-                <strong v-if="registration.consolidatedResult === 'Inabilitado'" class="danger__color">
+                <strong v-if="registration.consolidatedResult === 'invalid'" class="danger__color">
                     <mc-icon name="circle" class="danger__color"></mc-icon>{{registration.consolidatedResult}}
                     {{registration.consolidatedResult}}
                 </strong>

--- a/src/modules/Opportunities/Jobs/AutoApplicationResult.php
+++ b/src/modules/Opportunities/Jobs/AutoApplicationResult.php
@@ -63,7 +63,7 @@ class AutoApplicationResult extends JobType
             }
 
             if ($evaluation_type == 'qualification') {
-                $value = $registration->consolidatedResult == 'Habilitado' ? Registration::STATUS_APPROVED : Registration::STATUS_NOTAPPROVED;
+                $value = $registration->consolidatedResult == 'valid' ? Registration::STATUS_APPROVED : Registration::STATUS_NOTAPPROVED;
             }
 
             $app->disableAccessControl();

--- a/src/themes/BaseV2/assets-src/sass/2.components/_field.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_field.scss
@@ -89,19 +89,14 @@
             border: size(2) solid var(--mc-gray-100);
         }
         
-        & .input__checkboxLabel {
+        & .input__checkboxLabel, .input__radioLabel {
             display: flex;
             gap: size(8);
             font-size: var(--mc-font-size-xxs);
             font-weight: var(--mc-font-semibold);
         }
     }
-
-    .input__radioLabel {
-        font-size: var(--mc-font-size-xxs);
-        font-weight: var(--mc-font-semibold);
-    }
-
+    
     &__color {
         display: flex;
         gap: size(8);


### PR DESCRIPTION
Durante os testes no ambiente do Cultura Viva, identificamos um problema em que, ao habilitar uma inscrição pelas comissões de avaliação, ela era incorretamente marcada como inabilitada.