### PR TITLE
Ajusta layout de grupos de radio buttons no formulário de inscrição para evitar quebras visuais

### DIFF
--- a/src/modules/Entities/components/entity-field/template.php
+++ b/src/modules/Entities/components/entity-field/template.php
@@ -63,9 +63,11 @@ $this->import('
 
             <template v-else-if="is('select')">
                 <template v-if="description.registrationFieldConfiguration?.config?.viewMode === 'radio'">
-                    <label class="input__label input__radioLabel" v-for="(optionLabel, optionValue) in description.options">
-                        <input :checked="isRadioChecked(value, optionValue)" type="radio" :value="optionValue" @input="change($event,true)" @blur="change($event)" :disabled="readonly || disabled"> {{description.options[optionValue]}}
-                    </label>
+                    <div class="field__group">
+                        <label class="input__label input__radioLabel" v-for="(optionLabel, optionValue) in description.options">
+                            <input :checked="isRadioChecked(value, optionValue)" type="radio" :value="optionValue" @input="change($event,true)" @blur="change($event)" :disabled="readonly || disabled"> {{description.options[optionValue]}}
+                        </label>
+                    </div>
                 </template>
 
                 <select v-else :value="value" :id="propId" :name="prop" @input="change($event)" @blur="change($event,true)" :disabled="readonly || disabled">
@@ -74,9 +76,11 @@ $this->import('
             </template>
 
             <template v-else-if="is('radio')">
-                <label class="input__label input__radioLabel" v-for="(optionLabel, optionValue) in description.options">
-                    <input :checked="isRadioChecked(value, optionValue)" type="radio" :value="optionValue" @input="change($event,true)" @blur="change($event)" :disabled="readonly || disabled"> {{description.options[optionValue]}}
-                </label>
+                <div class="field__group">
+                    <label class="input__label input__radioLabel" v-for="(optionLabel, optionValue) in description.options">
+                        <input :checked="isRadioChecked(value, optionValue)" type="radio" :value="optionValue" @input="change($event,true)" @blur="change($event)" :disabled="readonly || disabled"> {{description.options[optionValue]}}
+                    </label>
+                </div>
             </template>
 
             <template v-else-if="is('links')">

--- a/src/modules/EvaluationMethodQualification/components/evaluation-qualification-detail/template.php
+++ b/src/modules/EvaluationMethodQualification/components/evaluation-qualification-detail/template.php
@@ -24,11 +24,11 @@ $this->import('
                 <label>
                     <?= i::__('Resultado: ') ?>
                 </label>
-                <strong v-if="registration.consolidatedResult === 'Habilitado'" class="success__color">
+                <strong v-if="registration.consolidatedResult === 'valid'" class="success__color">
                     <mc-icon name="circle" class="success__color"></mc-icon>{{registration.score}}
                     {{registration.consolidatedResult}}
                 </strong>
-                <strong v-if="registration.consolidatedResult === 'Inabilitado'" class="danger__color">
+                <strong v-if="registration.consolidatedResult === 'invalid'" class="danger__color">
                     <mc-icon name="circle" class="danger__color"></mc-icon>{{registration.consolidatedResult}}
                     {{registration.consolidatedResult}}
                 </strong>

--- a/src/modules/Opportunities/Jobs/AutoApplicationResult.php
+++ b/src/modules/Opportunities/Jobs/AutoApplicationResult.php
@@ -63,7 +63,7 @@ class AutoApplicationResult extends JobType
             }
 
             if ($evaluation_type == 'qualification') {
-                $value = $registration->consolidatedResult == 'Habilitado' ? Registration::STATUS_APPROVED : Registration::STATUS_NOTAPPROVED;
+                $value = $registration->consolidatedResult == 'valid' ? Registration::STATUS_APPROVED : Registration::STATUS_NOTAPPROVED;
             }
 
             $app->disableAccessControl();


### PR DESCRIPTION
Durante os testes no Cultura Viva, foi identificado um erro no front-end que causava quebras na exibição de campos com grupos de radio buttons. Este PR corrige o problema, garantindo que os campos sejam exibidos corretamente.