### PR TITLE
Melhoria nos filtros de eventos para incluir selo, estado e município

### DIFF
--- a/src/modules/Search/components/search-filter-agent/script.js
+++ b/src/modules/Search/components/search-filter-agent/script.js
@@ -1,7 +1,7 @@
 app.component('search-filter-agent', {
     template: $TEMPLATES['search-filter-agent'],
 
-    setup() { 
+    setup() {
         // os textos estão localizados no arquivo texts.php deste componente 
         const text = Utils.getTexts('search-filter-agent')
         return { text }

--- a/src/modules/Search/components/search-filter-agent/template.php
+++ b/src/modules/Search/components/search-filter-agent/template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var MapasCulturais\App $app
  * @var MapasCulturais\Themes\BaseV2\Theme $this
@@ -21,11 +22,11 @@ $this->import('
         <div class="field">
             <label> <?php i::_e('Status do agente') ?> </label>
             <label class="verified"><input v-model="pseudoQuery['@verified']" type="checkbox"> <?php i::_e('Agentes oficiais') ?> </label>
-        </div>  
+        </div>
         <div class="field">
             <label> <?php i::_e('Tipo') ?></label>
             <select v-model="pseudoQuery['type']">
-                <option :value="undefined"> <? i::_e('Todos')?> </option>
+                <option :value="undefined"> <?php i::_e('Todos') ?> </option>
                 <option value="1"> <?php i::_e('Agente Individual') ?> </option>
                 <option value="2"> <?php i::_e('Agente Coletivo') ?> </option>
             </select>

--- a/src/modules/Search/components/search-filter-event/script.js
+++ b/src/modules/Search/components/search-filter-event/script.js
@@ -1,14 +1,14 @@
 app.component('search-filter-event', {
     template: $TEMPLATES['search-filter-event'],
 
-    setup() { 
+    setup() {
         // os textos estão localizados no arquivo texts.php deste componente 
         const text = Utils.getTexts('search-filter-event');
         const parseDate = (date) => {
-            if(date instanceof Date) {
+            if (date instanceof Date) {
                 return new Date((new McDate(date)).date('sql') + ' 12:00:00');
             } else {
-                return new Date(date.substr(0,10) + ' 12:00:00');
+                return new Date(date.substr(0, 10) + ' 12:00:00');
             }
         }
 
@@ -19,7 +19,7 @@ app.component('search-filter-event', {
         }
 
         const today = parseDate(new Date());
-        const nextmonth = parseDate(Dates.addMonths(today,1));
+        const nextmonth = parseDate(Dates.addMonths(today, 1));
         const mctoday = new McDate(today);
         const mcnextmonth = new McDate(nextmonth);
         const startOfWeek = parseDate(Dates.startOfWeek(today));
@@ -29,59 +29,59 @@ app.component('search-filter-event', {
 
         const nextFriday = parseDate(Dates.nextFriday(startOfWeek));
         const nextSunday = parseDate(Dates.nextSunday(startOfWeek));
-        
+
         const ranges = {
-            yesterday: { 
-                label: __('ontem', 'search-filter-event'), 
-                range: [Dates.subDays(today,1), Dates.subDays(today,1)]   
+            yesterday: {
+                label: __('ontem', 'search-filter-event'),
+                range: [Dates.subDays(today, 1), Dates.subDays(today, 1)]
             },
-            today: { 
-                label: __('hoje', 'search-filter-event'), 
-                range: [today, today]   
+            today: {
+                label: __('hoje', 'search-filter-event'),
+                range: [today, today]
             },
-            tomorrow: { 
-                label: __('amanhã', 'search-filter-event'), 
-                range: [Dates.addDays(today,1), Dates.addDays(today,1)] 
+            tomorrow: {
+                label: __('amanhã', 'search-filter-event'),
+                range: [Dates.addDays(today, 1), Dates.addDays(today, 1)]
             },
-            lastWeek: { 
-                label: __('semana passada', 'search-filter-event'), 
-                range: [Dates.subWeeks(startOfWeek,1), Dates.subWeeks(endOfWeek,1)]
+            lastWeek: {
+                label: __('semana passada', 'search-filter-event'),
+                range: [Dates.subWeeks(startOfWeek, 1), Dates.subWeeks(endOfWeek, 1)]
             },
-            thisWeek: { 
-                label: __('esta semana', 'search-filter-event'), 
+            thisWeek: {
+                label: __('esta semana', 'search-filter-event'),
                 range: [startOfWeek, endOfWeek]
             },
-            nextWeek: { 
-                label: __('próxima semana', 'search-filter-event'), 
-                range: [Dates.addWeeks(startOfWeek,1), Dates.addWeeks(endOfWeek,1)]
+            nextWeek: {
+                label: __('próxima semana', 'search-filter-event'),
+                range: [Dates.addWeeks(startOfWeek, 1), Dates.addWeeks(endOfWeek, 1)]
             },
-            lastWeekend: { 
-                label: __('fim de semana passado', 'search-filter-event'), 
-                range: [Dates.subWeeks(nextFriday,1), Dates.subWeeks(nextSunday,1)]
+            lastWeekend: {
+                label: __('fim de semana passado', 'search-filter-event'),
+                range: [Dates.subWeeks(nextFriday, 1), Dates.subWeeks(nextSunday, 1)]
             },
-            thisWeekend: { 
-                label: __('este fim de semana', 'search-filter-event'), 
+            thisWeekend: {
+                label: __('este fim de semana', 'search-filter-event'),
                 range: [nextFriday, nextSunday]
             },
-            nextWeekend: { 
-                label: __('próximo fim de semana', 'search-filter-event'), 
-                range: [Dates.addWeeks(nextFriday,1), Dates.addWeeks(nextSunday,1)]
+            nextWeekend: {
+                label: __('próximo fim de semana', 'search-filter-event'),
+                range: [Dates.addWeeks(nextFriday, 1), Dates.addWeeks(nextSunday, 1)]
             },
-            last7days: { 
-                label: __('últimos 7 dias', 'search-filter-event'), 
-                range: [Dates.subDays(today,7), today]
+            last7days: {
+                label: __('últimos 7 dias', 'search-filter-event'),
+                range: [Dates.subDays(today, 7), today]
             },
-            next7days: { 
-                label: __('próximos 7 dias', 'search-filter-event'), 
-                range: [today, Dates.addDays(today,7)]
+            next7days: {
+                label: __('próximos 7 dias', 'search-filter-event'),
+                range: [today, Dates.addDays(today, 7)]
             },
-            last30days: { 
-                label: __('últimos 30 dias', 'search-filter-event'), 
-                range: [Dates.subDays(today,30), today]
+            last30days: {
+                label: __('últimos 30 dias', 'search-filter-event'),
+                range: [Dates.subDays(today, 30), today]
             },
-            next30days: { 
-                label: __('próximos 30 dias', 'search-filter-event'), 
-                range: [today, Dates.addDays(today,30)]
+            next30days: {
+                label: __('próximos 30 dias', 'search-filter-event'),
+                range: [today, Dates.addDays(today, 30)]
             },
             thisCurrentMonth: {
                 label: __('este mês', 'search-filter-event'),
@@ -107,8 +107,12 @@ app.component('search-filter-event', {
     beforeCreate() {
         this.defaultDateFrom = this.parseDate(this.pseudoQuery['@from']);
         this.defaultDateTo = this.parseDate(this.pseudoQuery['@to']);
+        this.pseudoQuery['event:name'] = this.pseudoQuery['event:name'] || [];
         this.pseudoQuery['event:term:linguagem'] = this.pseudoQuery['event:term:linguagem'] || [];
         this.pseudoQuery['event:classificacaoEtaria'] = this.pseudoQuery['event:classificacaoEtaria'] || [];
+        this.pseudoQuery['@seals'] = this.pseudoQuery['@seals'] || [];
+        this.pseudoQuery['En_Estado'] = this.pseudoQuery['En_Estado'] || [];
+        this.pseudoQuery['En_Municipio'] = this.pseudoQuery['En_Municipio'] || [];
     },
 
     props: {
@@ -119,12 +123,40 @@ app.component('search-filter-event', {
         pseudoQuery: {
             type: Object,
             required: true
-        }
+        },
     },
 
     watch: {
+        "pseudoQuery['@seals']": {
+            handler(value) {
+                if (value && value.length > 0) {
+                    this.query['@seals'] = value.map(v => v.value || v).join(',');
+                } else {
+                    delete this.query['@seals'];
+                }
+                this.$emit('filter-changed', this.query);
+            },
+            deep: true,
+        },
+        "pseudoQuery['En_Estado']": {
+            handler(value) {
+                // this.selectedStates = value;
+                this.filterByState();
+                this.$emit('changeStates', value);
+            },
+            deep: true,
+        },
+        "pseudoQuery['En_Municipio']": {
+            handler(value) {
+                // this.selectedCities = value;
+                this.filterByCities();
+                this.$emit('changeCities', value);
+            },
+            deep: true,
+        },
+
         date: {
-            handler(date){
+            handler(date) {
                 if (!date) {
                     this.date = [this.defaultDateFrom, this.defaultDateTo];
                     return;
@@ -136,7 +168,29 @@ app.component('search-filter-event', {
                 this.pseudoQuery['@to'] = d1.date('sql');
             },
             deep: true,
-        }
+        },
+    },
+
+    computed: {
+        states() {
+            return Object.fromEntries(
+                Object.entries(this.statesAndCities).map(([uf, estado]) => [uf, estado.label])
+            );
+        },
+        cities() {
+            const estadosSelecionados = this.pseudoQuery['En_Estado'] || [];
+            let cidades = {};
+
+            estadosSelecionados.forEach(uf => {
+                if (this.statesAndCities[uf]?.cities) {
+                    this.statesAndCities[uf].cities.forEach(cidade => {
+                        cidades[cidade] = estadosSelecionados.length > 1 ? `${cidade} - ${uf}` : cidade;
+                    });
+                }
+            });
+
+            return cidades;
+        },
     },
 
     data() {
@@ -153,21 +207,57 @@ app.component('search-filter-event', {
             this.ranges.thisYear,
         ];
 
+        let query = {
+            '@select': 'id,name,subTitle,files.avatar,seals.name,seals.id,terms,classificacaoEtaria,singleUrl',
+            '@order': 'createTimestamp DESC',
+            '@limit': 20,
+            '@page': 1,
+        }
+
         return {
             locale: $MAPAS.config.locale,
             terms: $TAXONOMIES.linguagem.terms,
+            query,
             date: [this.defaultDateFrom, this.defaultDateTo],
             presetRanges: presetRanges,
-            ageRating: $DESCRIPTIONS.event.classificacaoEtaria.optionsOrder
+            ageRating: $DESCRIPTIONS.event.classificacaoEtaria.optionsOrder,
+            sealsNames: $MAPAS.config.event_filters.seals.map(seal => ({
+                value: seal.id,
+                label: seal.name
+            })),
+            statesAndCities: $MAPAS.config.statesAndCities,
+            selectedStates: [],
+            selectedCities: [],
+            sealsLabels: Object.fromEntries($MAPAS.config.event_filters.seals.map(seal => [seal.id, seal.name])),
         }
     },
 
     methods: {
+        filterByState() {
+            if (this.selectedStates.length > 0) {
+                this.query['En_Estado'] = `IN(${this.selectedStates.toString()})`;
+            } else {
+                delete this.query['En_Estado'];
+            }
+            this.$emit('filter-changed', this.query);
+        },
+
+        filterByCities() {
+            if (this.selectedCities.length > 0) {
+                this.query['En_Municipio'] = `IN(${this.selectedCities.toString()})`;
+            } else {
+                delete this.query['En_Municipio'];
+            }
+            this.$emit('filter-changed', this.query);
+        },
+
         clearFilters() {
+            this.selectedStates = [];
+            this.selectedCities = [];
+
             const types = ['string', 'boolean'];
             this.date = [this.defaultDateFrom, this.defaultDateTo];
             for (const key in this.pseudoQuery) {
-                console.log(key+'\n', typeof this.pseudoQuery[key]);
                 if (['@from', '@to'].includes[key]) {
                     this.pseudoQuery[key] = new McDate(new Date(key == '@from' ? this.date[0] : this.date[1])).date('sql');
                 } else {
@@ -177,8 +267,10 @@ app.component('search-filter-event', {
                         delete this.pseudoQuery[key];
                     }
                 }
-            }       
+            }
+            this.$emit('filter-changed');
         },
+
         dateFormat(date) {
             const d0 = new Date(date[0]);
             const d1 = new Date(date[1]);
@@ -188,15 +280,15 @@ app.component('search-filter-event', {
             const d1s = mcd1.date('2-digit');
 
             // imprime o ano
-            if(this.isFirstDayOfYear(d0) && this.isLastDayOfYear(d1)) {
+            if (this.isFirstDayOfYear(d0) && this.isLastDayOfYear(d1)) {
                 return mcd0.year();
 
-            // imprime o mês
+                // imprime o mês
             } else if (Dates.isFirstDayOfMonth(d0) && Dates.isLastDayOfMonth(d1)) {
                 const mctoday = new McDate(new Date);
                 const thisYear = mctoday.year() == mcd0.year();
 
-                if(thisYear) {
+                if (thisYear) {
                     return Utils.ucfirst(mcd0.month());
                 } else {
                     return Utils.ucfirst(mcd0.month()) + ', ' + mcd0.year();
@@ -205,15 +297,15 @@ app.component('search-filter-event', {
 
             // imprime um preset
             const rangeString = this.toRangeString(date);
-            for(let preset of Object.values(this.ranges)) {
+            for (let preset of Object.values(this.ranges)) {
                 if (this.toRangeString(preset.range) == rangeString) {
                     return preset.label;
                 }
             }
 
             // imprime as datas selecionadas
-            if(d0s == d1s) {
-                return d0s;    
+            if (d0s == d1s) {
+                return d0s;
             } else {
                 return `${d0s} - ${d1s}`;
             }
@@ -224,15 +316,15 @@ app.component('search-filter-event', {
             const d1 = this.parseDate(this.date[1]);
 
             // trocando o ano
-            if(this.isFirstDayOfYear(d0) && this.isLastDayOfYear(d1)) {
-                
+            if (this.isFirstDayOfYear(d0) && this.isLastDayOfYear(d1)) {
+
                 const firstDay = Dates.addYears(d0, 1);
                 this.date = [
                     firstDay,
                     Dates.lastDayOfYear(firstDay)
                 ];
 
-            // trocando o mês
+                // trocando o mês
             } else if (Dates.isFirstDayOfMonth(d0) && Dates.isLastDayOfMonth(d1)) {
                 const firstDay = Dates.addMonths(d0, 1);
                 this.date = [
@@ -240,7 +332,7 @@ app.component('search-filter-event', {
                     Dates.lastDayOfMonth(firstDay)
                 ];
 
-            // trocando a semana
+                // trocando a semana
             } else if (Dates.isSunday(d0) && Dates.isSaturday(d1)) {
                 const firstDay = Dates.addWeeks(d0, 1);
                 this.date = [
@@ -248,23 +340,23 @@ app.component('search-filter-event', {
                     Dates.lastDayOfWeek(firstDay)
                 ];
 
-            // trocando o fim de semana
+                // trocando o fim de semana
             } else if (Dates.isFriday(d0) && Dates.isSunday(d1)) {
                 this.date = [
-                    Dates.addWeeks(d0,1),
-                    Dates.addWeeks(d1,1),
+                    Dates.addWeeks(d0, 1),
+                    Dates.addWeeks(d1, 1),
                 ];
 
-            // trocando o dia
+                // trocando o dia
             } else if (Dates.isSameDay(d0, d1)) {
                 this.date = [
-                    Dates.addDays(d0,1),
-                    Dates.addDays(d1,1),
+                    Dates.addDays(d0, 1),
+                    Dates.addDays(d1, 1),
                 ];
 
-            // outros intervalos
+                // outros intervalos
             } else {
-                const diff = Dates.differenceInDays(d1,d0);
+                const diff = Dates.differenceInDays(d1, d0);
                 this.date = [
                     d1,
                     Dates.addDays(d1, diff)
@@ -275,16 +367,16 @@ app.component('search-filter-event', {
         prevInterval() {
             const d0 = this.parseDate(this.date[0]);
             const d1 = this.parseDate(this.date[1]);
-            
+
             // trocando o ano
-            if(this.isFirstDayOfYear(d0) && this.isLastDayOfYear(d1)) {
+            if (this.isFirstDayOfYear(d0) && this.isLastDayOfYear(d1)) {
                 const firstDay = Dates.subYears(d0, 1);
                 this.date = [
                     firstDay,
                     Dates.subDays(d0, 1)
                 ];
-            
-            // trocando o mês
+
+                // trocando o mês
             } else if (Dates.isFirstDayOfMonth(d0) && Dates.isLastDayOfMonth(d1)) {
                 const firstDay = Dates.subMonths(d0, 1);
                 this.date = [
@@ -292,32 +384,32 @@ app.component('search-filter-event', {
                     Dates.subDays(d0, 1)
                 ];
 
-            // trocando a semana
+                // trocando a semana
             } else if (Dates.isSunday(d0) && Dates.isSaturday(d1)) {
                 this.date = [
                     Dates.subWeeks(d0, 1),
                     Dates.subWeeks(d1, 1)
                 ];
 
-            // trocando o fim de semana
+                // trocando o fim de semana
             } else if (Dates.isFriday(d0) && Dates.isSunday(d1)) {
                 this.date = [
-                    Dates.subWeeks(d0,1),
-                    Dates.subWeeks(d1,1),
+                    Dates.subWeeks(d0, 1),
+                    Dates.subWeeks(d1, 1),
                 ];
 
-            // trocando o dia
+                // trocando o dia
             } else if (Dates.isSameDay(d0, d1)) {
                 this.date = [
-                    Dates.subDays(d0,1),
-                    Dates.subDays(d1,1),
+                    Dates.subDays(d0, 1),
+                    Dates.subDays(d1, 1),
                 ];
 
-            // outros intervalos
+                // outros intervalos
             } else {
-                const diff = Dates.differenceInDays(d1,d0);
+                const diff = Dates.differenceInDays(d1, d0);
                 this.date = [
-                    Dates.subDays(d0, diff), 
+                    Dates.subDays(d0, diff),
                     d0
                 ];
 

--- a/src/modules/Search/components/search-filter-event/template.php
+++ b/src/modules/Search/components/search-filter-event/template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var MapasCulturais\App $app
  * @var MapasCulturais\Themes\BaseV2\Theme $this
@@ -6,30 +7,44 @@
 
 use MapasCulturais\i;
 
+$queryParams =  [
+    '@order' => 'id ASC',
+    '@select' => 'id,name,files.avatar',
+];
+$querySeals = new MapasCulturais\ApiQuery(MapasCulturais\Entities\Seal::class, $queryParams);
+
+$this->jsObject['config']['event_filters'] = [
+    'seals' => $querySeals->getFindResult(),
+];
+
 $this->import('
     mc-icon
-    mc-multiselect 
+    mc-currency-input
+    mc-multiselect
     mc-tag-list
-    search-filter 
+    search-filter
 ');
 ?>
 <search-filter :position="position" :pseudo-query="pseudoQuery">
-    <label class="form__label">
-        <?= i::_e('Filtros de eventos') ?>
-    </label>
-    <form class="form" @submit="$event.preventDefault()">
+    <div style="display: flex; align-items: stretch;">
+        <mc-icon name="filter" style="color: #2B74D9; font-size: 1.1rem;"></mc-icon>
+        <label class="form__label" style="margin-left: 10px; color: #2B74D9; line-height: 1.1rem;">
+            <?= i::_e('Filtros') ?>
+        </label>
+    </div>
+    <form class="form" @submit="$event.preventDefault()" style="max-height: none !important;">
         <?php $this->applyTemplateHook('search-filter-event', 'begin') ?>
         <div class="field">
-            <label> <?php i::_e('Eventos acontecendo') ?></label>
+            <label> <?php i::_e('Período') ?></label>
             <div class="datepicker">
-                <datepicker 
+                <datepicker
                     :teleport="true"
-                    :locale="locale" 
+                    :locale="locale"
                     :weekStart="0"
-                    v-model="date" 
-                    :enableTimePicker='false' 
+                    v-model="date"
+                    :enableTimePicker='false'
                     :format="dateFormat"
-                    :presetRanges="presetRanges" 
+                    :presetRanges="presetRanges"
                     :dayNames="['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sab']"
                     range multiCalendars multiCalendarsSolo autoApply teleport-center utc></datepicker>
                 <div class="filter-btn">
@@ -39,20 +54,68 @@ $this->import('
             </div>
         </div>
         <div class="field">
-            <label> <?php i::_e('Status do evento') ?></label>
-            <label class="verified"><input v-model="pseudoQuery['event:@verified']" type="checkbox"> <?php i::_e('Eventos oficiais') ?> </label>
+            <label class="verified"><input v-model="pseudoQuery['@verified']" type="checkbox"> <?php i::_e('Eventos oficiais') ?> </label>
         </div>
+
         <div class="field">
-            <label> <?php i::_e('Classificação Etária') ?></label>
-            <mc-multiselect :model="pseudoQuery['event:classificacaoEtaria']" placeholder="<?php i::_e('Classificação Etária')?>" :items="ageRating" hide-filter hide-button></mc-multiselect>
-            <mc-tag-list editable :tags="pseudoQuery['event:classificacaoEtaria']" classes="event__background event__color"></mc-tag-list>
+            <label><?= i::__('Estado') ?></label>
+            <mc-multiselect
+                :model="pseudoQuery['En_Estado']"
+                :items="states"
+                @change="filterByState"
+                title="<?php i::_e('Estado') ?>"
+                placeholder="<?= i::esc_attr__('Todos') ?>"
+                hide-filter
+                hide-button></mc-multiselect>
+            <mc-tag-list
+                editable
+                :tags="pseudoQuery['En_Estado']"
+                :labels="states"
+                classes="agent__background agent__color"></mc-tag-list>
         </div>
+
+        <div class="field">
+            <label><?= i::__('Municípios') ?></label>
+            <mc-multiselect
+                :model="pseudoQuery['En_Municipio']"
+                :items="cities"
+                @change="filterByCities"
+                title="<?php i::_e('Municípios') ?>"
+                placeholder="<?= i::esc_attr__('Todos') ?>"
+                :disabled="!pseudoQuery['En_Estado']?.length"
+                hide-filter
+                hide-button></mc-multiselect>
+            <mc-tag-list
+                editable
+                :tags="pseudoQuery['En_Municipio']"
+                :labels="cities"
+                classes="agent__background agent__color"></mc-tag-list>
+        </div>
+
+        <div class="field">
+            <label> <?php i::_e('Selos') ?></label>
+            <mc-multiselect class="col-3 sm:col-4" :model="pseudoQuery['@seals']" :items="sealsNames" placeholder="<?= i::esc_attr__('Todos') ?>" :hide-filter="hideFilters" hide-button></mc-multiselect>
+            <mc-tag-list editable :tags="pseudoQuery['@seals']" :labels="sealsLabels" classes="event__background event__color"></mc-tag-list>
+        </div>
+
         <div class="field">
             <label> <?php i::_e('Linguagens') ?></label>
-            <mc-multiselect :model="pseudoQuery['event:term:linguagem']" :items="terms" placeholder="<?php i::_e('Selecione as linguagens') ?>" hide-filter hide-button></mc-multiselect>
+            <mc-multiselect :model="pseudoQuery['event:term:linguagem']" placeholder="<?= i::esc_attr__('Todas') ?>" :items="terms" title="<?php i::_e('Selecione as linguagens') ?>" hide-filter hide-button></mc-multiselect>
             <mc-tag-list editable :tags="pseudoQuery['event:term:linguagem']" classes="event__background event__color"></mc-tag-list>
         </div>
+
+        <div class="field">
+            <label> <?php i::_e('Classificação Etária') ?></label>
+            <mc-multiselect :model="pseudoQuery['event:classificacaoEtaria']" placeholder="<?= i::esc_attr__('Todas') ?>" title="<?php i::_e('Classificação Etária') ?>" :items="ageRating" hide-filter hide-button></mc-multiselect>
+            <mc-tag-list editable :tags="pseudoQuery['event:classificacaoEtaria']" classes="event__background event__color"></mc-tag-list>
+        </div>
+
+        <div class="field">
+            <label> <?php i::_e('Nome do evento') ?></label>
+            <input id="name" type="text" v-model="pseudoQuery['event:name']" placeholder="<?= i::esc_attr__('Digite') ?>" />
+        </div>
+
         <?php $this->applyTemplateHook('search-filter-event', 'end') ?>
     </form>
-    <a class="clear-filter" @click="clearFilters()"><?php i::_e('Limpar todos os filtros') ?></a>
+    <a class="clear-filter" @click="clearFilters()"><?php i::_e('limpar todos os filtros') ?></a>
 </search-filter>

--- a/src/modules/Search/components/search-list-event/template.php
+++ b/src/modules/Search/components/search-list-event/template.php
@@ -21,6 +21,9 @@ $this->import('
     <mc-loading :condition="loading && page == 1"></mc-loading>
     <div v-if="!loading || page > 1" class="col-9 search-list__cards">
         <div class="grid-12">
+            <div v-if="!loading && occurrences.length === 0" class="col-12 no-results">
+                <h3>Nenhum evento encontrado.</h3>
+            </div>
             <div v-for="occurrence in occurrences" :key="occurrence._reccurrence_string" class="col-12">
                 <div v-if="newDate(occurrence)" class="search-list__cards--date">
                     <div class="search-list__cards--date-info">

--- a/src/modules/Search/components/search-list-event/template.php
+++ b/src/modules/Search/components/search-list-event/template.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var MapasCulturais\App $app
  * @var MapasCulturais\Themes\BaseV2\Theme $this
@@ -14,7 +15,7 @@ $this->import('
 <div class="grid-12 search-list">
     <div class="col-3 search-list__filter">
         <div class="search-list__filter--filter">
-            <search-filter-event :pseudo-query="pseudoQuery"></search-filter-event>
+            <search-filter-event :pseudo-query="pseudoQuery" :filter-changed="fetchOccurrences"></search-filter-event>
         </div>
     </div>
     <mc-loading :condition="loading && page == 1"></mc-loading>
@@ -23,17 +24,17 @@ $this->import('
             <div v-for="occurrence in occurrences" :key="occurrence._reccurrence_string" class="col-12">
                 <div v-if="newDate(occurrence)" class="search-list__cards--date">
                     <div class="search-list__cards--date-info">
-                        <h2 v-if="occurrence.starts.isToday()" class="actual-date"><?= i::__('Hoje') ?><label class="month"><?= i::__('{{occurrence.starts.month()}}')?></label></h2>
-                        <h2 v-else-if="occurrence.starts.isTomorrow()" class="actual-date"><?= i::__('Amanhã') ?><label class="month"><?= i::__('{{occurrence.starts.month()}}')?></label></h2>
-                        <h2 v-else-if="occurrence.starts.isYesterday()" class="actual-date"><?= i::__('Ontem') ?><label class="month"><?= i::__('{{occurrence.starts.month()}}')?></label></h2>
+                        <h2 v-if="occurrence.starts.isToday()" class="actual-date"><?= i::__('Hoje') ?><label class="month"><?= i::__('{{occurrence.starts.month()}}') ?></label></h2>
+                        <h2 v-else-if="occurrence.starts.isTomorrow()" class="actual-date"><?= i::__('Amanhã') ?><label class="month"><?= i::__('{{occurrence.starts.month()}}') ?></label></h2>
+                        <h2 v-else-if="occurrence.starts.isYesterday()" class="actual-date"><?= i::__('Ontem') ?><label class="month"><?= i::__('{{occurrence.starts.month()}}') ?></label></h2>
                         <template v-else>
-                            <h2 class="actual-date" >{{occurrence.starts.day()}}<label class="month"><?= i::__('{{occurrence.starts.month()}}')?></label></h2>
+                            <h2 class="actual-date">{{occurrence.starts.day()}}<label class="month"><?= i::__('{{occurrence.starts.month()}}') ?></label></h2>
                         </template>
                         <label class="weekend">{{occurrence.starts.weekday()}}</label>
                     </div>
                     <div class="search-list__cards--date-line"></div>
                 </div>
-                <occurrence-card :occurrence="occurrence" ></occurrence-card>
+                <occurrence-card :occurrence="occurrence"></occurrence-card>
             </div>
 
             <div v-if="occurrences.metadata.page < occurrences.metadata.numPages" class="col-12 load-more">


### PR DESCRIPTION
## Visão Geral

Este PR aprimora os filtros da página de eventos, adicionando opções para filtrar por selo, estado e município. Isso permite uma busca mais precisa e facilita a visualização de eventos específicos conforme localização e características dos selos associados. 
## Principais Modificações Realizadas no frontend:

- componenetes afetados: search-list-event, search-filter-event e search-filter-agent
- Adição do filtro por selo nos eventos.  
- Inclusão do filtro por estado.  
- Inclusão do filtro por município.  
- Ajustes na UI para acomodar os novos filtros.  
- Atualização da lógica de consulta para aplicar os novos filtros corretamente
- Adiciona mensagem se nenhum evento for encontrado

## Principais Modificações Realizadas na API:

1. Filtragem por Estado e Município:

- Adicionada funcionalidade de filtro por estado (En_Estado) e município (En_Municipio)
- Implementada lógica para extrair valores de filtros IIN()
- Adicionada consulta SQL para obter estado e município do espaço
- Implementada validação para filtrar ocorrências baseadas nesses critérios

2. Melhorias na API de Ocorrências:

- Adicionado suporte a metadados para paginação
- Implementado controle de cache configurável
- Adicionado suporte para usuário de presença (attendance)
- Melhorado o formato de retorno das datas e horários

3. Integração com Espaços:

- Adicionado suporte a subsites na filtragem de espaços
- Implementada lógica para consulta de metadados dos espaços
- Melhorada a relação entre eventos e espaços
