### PR TITLE
Correção da exportação de inscritos

### DIFF
--- a/src/modules/Spreadsheets/JobTypes/Registrations.php
+++ b/src/modules/Spreadsheets/JobTypes/Registrations.php
@@ -269,7 +269,7 @@ class Registrations extends SpreadsheetJob
                             continue;
                         }
 
-                        $values = array_map(function($item) use ($field, $entity) {
+                        $values = array_map(function($item) use ($field) {
                             if (!is_object($item)) {
                                 return $item;
                             }


### PR DESCRIPTION
# Cenário

Ao exportar a lista de inscritos de um edital que em seu formulário está utilizando um campo de  *Listagem de Endereços* ao exportar, o arquivo vinha vazio

<img width="1162" height="483" alt="image" src="https://github.com/user-attachments/assets/b6380ca6-b6aa-44c6-b80e-7c7e5005f3fe" />

<img width="191" height="466" alt="image" src="https://github.com/user-attachments/assets/36b6e96e-e167-4462-8611-478be3aa9b84" />

# Solução

* Adicionar uma formatação específica para o campo de *Listagem de Endereços*
* Rever validações de formatação para arrays

<img width="1153" height="108" alt="image" src="https://github.com/user-attachments/assets/f327a56e-29c2-4949-b5cc-5e9139ca0da5" />
