### PR TITLE
Adiciona suporte a autenticação jwt nas requisições para api

### DIFF
--- a/config/middlewares.php
+++ b/config/middlewares.php
@@ -1,5 +1,7 @@
 <?php 
 
 return [
-    'middlewares' => []
+    'middlewares' => [
+        Apps\Middleware\JWTAuthMiddleware::class
+    ]
 ];

--- a/dev/config.d/middlewares.php
+++ b/dev/config.d/middlewares.php
@@ -1,6 +1,7 @@
 <?php
 return [
     'middlewares' => [
-        MapasCulturais\Middlewares\ExecutionTime::class
+        MapasCulturais\Middlewares\ExecutionTime::class,
+        Apps\Middleware\JWTAuthMiddleware::class
     ]
 ];

--- a/src/modules/Apps/Middleware/JWTAuthMiddleware.php
+++ b/src/modules/Apps/Middleware/JWTAuthMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+namespace Apps\Middleware;
+
+use Apps\Entities\UserApp;
+use Apps\JWTAuthProvider;
+use MapasCulturais\App;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class JWTAuthMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $app = App::i();
+        // Get Authorization header (case-insensitive) and strip optional Bearer prefix
+        $authHeader = $request->getHeaderLine('Authorization');
+        if ($authHeader) {
+            $token = $authHeader;
+            if (stripos($token, 'Bearer ') === 0) {
+                $token = substr($token, 7);
+            }
+
+            // Switch the auth provider just for this request
+            $app->auth = new JWTAuthProvider(['token' => $token]);
+        }
+        
+        return $handler->handle($request);
+    }
+}


### PR DESCRIPTION
## Descrição

Este PR adiciona uma middleware para ativar a autenticação via JWT (JSON Web Token) nas requisições à API. Em resumo, permite que endpoints que requerem autenticação verifiquem o token JWT antes de processar a requisição.

## O que foi feito

Introdução de uma nova camada de middleware para interceptar requisições da API e validar o token JWT.

Configuração inicial para que, quando ativa, a autenticação seja exigida por padrão em rotas protegidas.

Garantia de que o fluxo de requisições não autenticadas para rotas protegidas seja bloqueado ou encaminhado para resposta de erro apropriada.

## Por que isso importa

Aumenta a segurança da API ao exigir autenticação para operações sensíveis.

Facilita futura implementação de funcionalidades que dependem de identificação de usuário/autorização (por exemplo, endpoints de criação, edição ou exclusão de conteúdo).

Melhora a arquitetura de backend ao separar claramente a lógica de autenticação da lógica de negócio das rotas.
