### PR TITLE
fix: corrigindo busca pela chave primária da tabela de Jobs

### DIFF
--- a/src/core/Entities/Job.php
+++ b/src/core/Entities/Job.php
@@ -215,7 +215,7 @@ class Job extends \MapasCulturais\Entity{
 
         if ($success !== false){
             // para evitar que um eventual erro no job deixe a entidade detached
-            $job = $app->repo('Job')->find($this->id) ?: $this;
+            $job = $app->repo('Job')->find($this->pk) ?: $this;
 
             $job->iterationsCount++;
             


### PR DESCRIPTION
# Cenário

O Doctrine utiliza a propriedade marcada com `@ORM\Id` ao executar `->find()`. Como estávamos passando `$this->id` — que **não** está marcada como `@ORM\Id` — o Doctrine tentava converter o valor de integer para sequence, gerando erro de tipo.

<img width="941" height="438" alt="image" src="https://github.com/user-attachments/assets/53a12eba-7611-4ecf-a12c-3e9dd11480f7" />

# ERRO

![WhatsApp Image 2025-11-17 at 08 58 31](https://github.com/user-attachments/assets/3cc894cb-cf2d-4b58-85da-df1cfba47d3c)

# Solução

Passar a propriedade `$pk`, que é sequencial e corretamente marcada como `@ORM\Id`

# OBSERVAÇÕES

Esta correção já foi repassada (e incorporada) à comunidade através do https://github.com/mapasculturais/mapasculturais/pull/3555