### PR TITLE
Corrige bug com campos @location no registration 

### DIFF
--- a/src/modules/RegistrationFieldTypes/Module.php
+++ b/src/modules/RegistrationFieldTypes/Module.php
@@ -868,28 +868,19 @@ class Module extends \MapasCulturais\Module
             $taxonomies_fields = $this->taxonomiesOpportunityFields();
 
             if($entity_field == '@location'){
-
-                if($entity->En_Nome_Logradouro && $entity->En_Num && $entity->En_Municipio && $entity->En_Estado) {
-                    $result = [
-                        'endereco' => $entity->endereco,
-                        'En_CEP' => $entity->En_CEP,
-                        'En_Nome_Logradouro' => $entity->En_Nome_Logradouro,
-                        'En_Num' => $entity->En_Num,
-                        'En_Complemento' => $entity->En_Complemento,
-                        'En_Bairro' => $entity->En_Bairro,
-                        'En_Municipio' => $entity->En_Municipio,
-                        'En_Estado' => $entity->En_Estado,
-                        'location' => $entity->location,
-                        'publicLocation' => $entity->publicLocation
-                    ];
-                    if (isset($entity->En_Pais)) {
-                        $result["En_Pais"] = $entity->En_Pais;
-                    }
-                } else {
-                    $result = null;
-                }
-
-                $value = $result;
+                $value = [
+                    'endereco' => $entity->endereco,
+                    'En_CEP' => $entity->En_CEP,
+                    'En_Nome_Logradouro' => $entity->En_Nome_Logradouro,
+                    'En_Num' => $entity->En_Num,
+                    'En_Complemento' => $entity->En_Complemento,
+                    'En_Bairro' => $entity->En_Bairro,
+                    'En_Municipio' => $entity->En_Municipio,
+                    'En_Estado' => $entity->En_Estado,
+                    'En_Pais' => $entity->En_Pais,
+                    'location' => $entity->location,
+                    'publicLocation' => $entity->publicLocation
+                ];
 
             } else if($taxonomies_fields && in_array($entity_field, array_keys($taxonomies_fields))) {
                 $term = $taxonomies_fields[$entity_field];


### PR DESCRIPTION


Melhorias

A função fetchFromEntity só retornava os dados de endereço se todos os 4 campos (En_Nome_Logradouro, En_Num, En_Municipio, En_Estado) estivessem preenchidos. Caso contrário, retornava null. Depois: A função agora sempre retorna o objeto com todos os campos de endereço (incluindo En_Pais que estava sendo tratado separadamente), independentemente de quais campos estão preenchidos.

Benefícios:

Endereços parciais são "puxados" corretamente para novas inscrições
Endereços internacionais (com En_Pais diferente de BR) funcionam corretamente
O campo En_Pais agora é sempre incluído no retorno (antes só era adicionado condicionalmente)
Consistência com o saveToEntity que sempre salva todos os campos

Testes

Criar oportunidade com campo @ de endereço
Fazer primeira inscrição e preencher o campo
Verificar se as infos foram salvas no perfil do agente
Criar nova inscrição e verificar se os valores são preenchidos automaticamente
