### PR TITLE
fix: corrige problema de sobrescrita de evaluationStatusDict

### DIFF
--- a/src/modules/Opportunities/components/opportunity-registrations-table/init.php
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/init.php
@@ -11,33 +11,6 @@ foreach($registrations as $status => $status_name){
     }
 }
 
-$data['evaluationStatusDict'] = [
-    'simple' => [
-        '0'  => i::__('Não avaliada'),
-        '2'  => i::__('Inválida'),
-        '3'  => i::__('Não selecionada'),
-        '8'  => i::__('Suplente'),
-        '10' => i::__('Selecionada')
-    ],
-    'documentary' => [
-        '0'  => i::__('Não avaliada'),
-        '1' => i::__('Válida'),
-        '-1' => i::__('Inválida'),
-    ],
-    'qualification' => [
-        '0'  => i::__('Não avaliada'),
-        'Habilitado' => i::__('Habilitado'),
-        'Inabilitado' => i::__('Inabilitado'),
-    ],
-    'continuous' => [
-        '0'  => i::__('Não avaliada'),
-        '2'  => i::__('Inválida'),
-        '3'  => i::__('Não selecionada'),
-        '8'  => i::__('Suplente'),
-        '10' => i::__('Selecionada')
-    ]
-];
-
 $phase = $this->controller->requestedEntity;
 
 $data['isAffirmativePoliciesActive'] = $phase->isAffirmativePoliciesActive();
@@ -227,13 +200,20 @@ $data['evaluationStatusDict'] = [
     ],
     'documentary' => [
         '0'  => i::__('Não avaliada'),
-        '1'  => i::__('Válida'),
+        '1' => i::__('Válida'),
         '-1' => i::__('Inválida'),
     ],
     'qualification' => [
         '0'  => i::__('Não avaliada'),
         'Habilitado' => i::__('Habilitado'),
         'Inabilitado' => i::__('Inabilitado'),
+    ],
+    'continuous' => [
+        '0'  => i::__('Não avaliada'),
+        '2'  => i::__('Inválida'),
+        '3'  => i::__('Não selecionada'),
+        '8'  => i::__('Suplente'),
+        '10' => i::__('Selecionada')
     ]
 ];
 

--- a/src/modules/Opportunities/components/opportunity-registrations-table/init.php
+++ b/src/modules/Opportunities/components/opportunity-registrations-table/init.php
@@ -3,14 +3,6 @@
 use MapasCulturais\i;
 use MapasCulturais\Entities\Registration;
 
-$registrations = Registration::getStatusesNames();
-
-foreach($registrations as $status => $status_name){
-    if(in_array($status,[0,1,2,3,8,10])){
-        $data["registrationStatusDict"][] = ["label" => $status_name, "value" => $status];
-    }
-}
-
 $phase = $this->controller->requestedEntity;
 
 $data['isAffirmativePoliciesActive'] = $phase->isAffirmativePoliciesActive();


### PR DESCRIPTION
# Cenário

A lista de Recursos Enviados não carrega

# Solução
- [x] Realiza a correção de sobrescrita de mapeamento de valores em evaluationStatusDict
- [x] Remoção de trecho repetido

# Erro

<img width="1127" height="559" alt="image" src="https://github.com/user-attachments/assets/c1d2bd50-37c4-4299-a830-9967d2658127" />

<img width="708" height="187" alt="image" src="https://github.com/user-attachments/assets/52e3ec0f-afa8-4bb1-9712-9ea83db82f5a" />

# Resultado

<img width="1160" height="637" alt="image" src="https://github.com/user-attachments/assets/702179a0-94d8-4018-8479-ba2aa95702af" />
