### PR TITLE
🐛 Bug: entrega desaparece após salvar a meta (regressão)

### DIFF
--- a/src/modules/OpportunityWorkplan/Services/WorkplanService.php
+++ b/src/modules/OpportunityWorkplan/Services/WorkplanService.php
@@ -104,7 +104,14 @@ class WorkplanService
         // (cujas collections ArrayCollection em memória estão vazias) sejam
         // retornadas corretamente na serialização — corrige bug de entrega
         // desaparecendo após salvar a meta.
+        // refresh($workplan) sozinho não basta: as goals ainda presentes na
+        // Identity Map conservam suas ArrayCollections vazias. É preciso
+        // refresh em cada goal para que a coleção deliveries seja
+        // reinicializada e recarregada do banco na serialização.
         $app->em->refresh($workplan);
+        foreach ($workplan->goals as $goal) {
+            $app->em->refresh($goal);
+        }
 
         return $workplan;        
     }


### PR DESCRIPTION
## Correções adicionais — plano de metas (workplan)

### 🐛 Bug: entrega desaparece após salvar a meta (regressão)

**Sintoma:** ao preencher uma atividade/entrega e clicar em "Salvar meta", a entrega sumia da tela. Ao recarregar a página (F5), ela reaparecia corretamente.

**Causa raiz (Identity Map do Doctrine):**

O fix anterior adicionava `$app->em->refresh($workplan)` antes do retorno — o que recria a coleção `goals` como "não inicializada". Porém, ao iterar sobre `goals` na serialização, o Doctrine encontrava cada `Goal` **já presente na Identity Map** (persistido na mesma requisição) e retornava a instância em memória, que ainda tinha `$this->deliveries = new ArrayCollection()` **vazia** (setada no construtor do `new Goal()`). As entregas que tinham sido salvas no banco não eram carregadas.

**Fix aplicado (`WorkplanService.php`):**

```php
$app->em->refresh($workplan);
foreach ($workplan->goals as $goal) {
    $app->em->refresh($goal);     // ← linha adicionada
}