### PR TITLE
Melhorias no fluxo de criação de agente dentro da inscrição em oportunidade

### DIFF
--- a/src/modules/Components/components/mc-popover/script.js
+++ b/src/modules/Components/components/mc-popover/script.js
@@ -46,6 +46,11 @@ app.component('mc-popover', {
         document.addEventListener('mousedown', (event) => {
             let contained = false;
             const slotPopover = document.getElementsByClassName('v-popper__popper');
+            const modalContent = event.target.closest('.modal-container') || event.target.closest('.modal-content');
+
+            if (modalContent) {
+                contained = true;
+            }
 
             for (let popover of slotPopover) {
                 let buttonAriaDescribedby = event.target.getAttribute("aria-describedby") ?? (event.target.closest("a") ? event.target.closest("a").getAttribute("aria-describedby") : null);

--- a/src/modules/Components/components/select-entity/script.js
+++ b/src/modules/Components/components/select-entity/script.js
@@ -73,6 +73,10 @@ app.component('select-entity', {
             type: Boolean,
             default: false
         },
+        createNewType: {
+            type: Number,
+            default: 1
+        },
         scope: {
             type: String
         },
@@ -97,6 +101,10 @@ app.component('select-entity', {
         selectEntity(entity, close) {
             this.$emit('select', entity);
             close();
+        },
+
+        refreshEntities() {
+            this.$refs.entitiesList?.refresh?.();
         },
         
         fetch(entities) {

--- a/src/modules/Components/components/select-entity/template.php
+++ b/src/modules/Components/components/select-entity/template.php
@@ -67,7 +67,7 @@ $this->import('
                         </create-space>
                         <create-agent v-if="type=='agent'" teleport="body" :click-to-close="false" :initial-type="createNewType" @create="refreshEntities()">
                             <template #default="{modal}">
-                                <button class="button button--primary-outline button--large" @click="modal.open()"><?php i::_e('Criar agente') ?> </button>
+                                <button class="button button--primary-outline button--large" @click="modal.open(); close()"><?php i::_e('Criar agente') ?> </button>
                             </template>
                         </create-agent>
                     </div>

--- a/src/modules/Components/components/select-entity/template.php
+++ b/src/modules/Components/components/select-entity/template.php
@@ -23,7 +23,7 @@ $this->import('
 
         <template #default="{ close }">
             <div class="select-entity">
-                <mc-entities :type="type" :select="select" :query="query" :limit="limit" order="name ASC" :scope="scope" :permissions="permissions" @fetch="fetch($event)" watch-query>
+                <mc-entities ref="entitiesList" :type="type" :select="select" :query="query" :limit="limit" order="name ASC" :scope="scope" :permissions="permissions" @fetch="fetch($event)" watch-query>
                     <template #header="{entities}">
                         <form class="select-entity__form" @submit="entities.refresh(); $event.preventDefault();">
                             <input ref="searchKeyword" v-model="entities.query['@keyword']" type="text" class="select-entity__form--input" name="searchKeyword" :placeholder="placeholder" @keyup="entities.refresh(500)"/>
@@ -65,7 +65,7 @@ $this->import('
                                 <button class="button button--primary-outline button--large" @click="modal.open()"><?php i::_e('Criar espaço') ?> </button>
                             </template>
                         </create-space>
-                        <create-agent v-if="type=='agent'">
+                        <create-agent v-if="type=='agent'" teleport="body" :click-to-close="false" :initial-type="createNewType" @create="refreshEntities()">
                             <template #default="{modal}">
                                 <button class="button button--primary-outline button--large" @click="modal.open()"><?php i::_e('Criar agente') ?> </button>
                             </template>

--- a/src/modules/Entities/components/create-agent/script.js
+++ b/src/modules/Entities/components/create-agent/script.js
@@ -25,6 +25,18 @@ app.component('create-agent', {
             type: Boolean,
             default: true
         },
+        clickToClose: {
+            type: Boolean,
+            default: true
+        },
+        initialType: {
+            type: Number,
+            default: 1
+        },
+        teleport: {
+            type: null,
+            default: false
+        },
     },
 
     computed: {
@@ -69,7 +81,7 @@ app.component('create-agent', {
         },
         createEntity() {
             this.entity = Vue.ref(new Entity('agent'));
-            this.entity.type = 1;
+            this.entity.type = this.initialType;
             this.entity.terms = { area: [] }
         },
         createDraft(modal) {

--- a/src/modules/Entities/components/create-agent/template.php
+++ b/src/modules/Entities/components/create-agent/template.php
@@ -13,7 +13,7 @@ $this->import('
     mc-modal 
 '); 
 ?>
-<mc-modal :title="modalTitle" classes="create-modal create-agent-modal" button-label="<?php i::_e('Criar Agente')?>"  @open="createEntity()" @close="destroyEntity()">
+<mc-modal :title="modalTitle" :teleport="teleport" :click-to-close="clickToClose" classes="create-modal create-agent-modal" button-label="<?php i::_e('Criar Agente')?>"  @open="createEntity()" @close="destroyEntity()">
     <template v-if="entity && !entity.id" #default>
         <label><?php i::_e('Crie um agente com informações básicas')?><br><?php i::_e('e de forma rápida')?></label>
         <div class="create-modal__fields">

--- a/src/modules/Opportunities/components/opportunity-subscription/template.php
+++ b/src/modules/Opportunities/components/opportunity-subscription/template.php
@@ -40,7 +40,7 @@ $this->import('
 			<!-- Logado -->
 			<form class="logged__form grid-12" @submit.prevent>
 				<div class="col-6 sm:col-12 opportunity-subscription__selectAgents" v-if="entitiesLength > 1">
-					<select-entity type="agent" openside="down-right" :query="{'type': 'EQ(1)'}" select="name,files.avatar,endereco,location" @fetch="fetch($event)" @select="selectAgent($event)" classes="opportunity-subscription__popover">
+					<select-entity type="agent" openside="down-right" :createNew="true" :create-new-type="1" :query="{'type': 'EQ(1)'}" select="name,files.avatar,endereco,location" @fetch="fetch($event)" @select="selectAgent($event)" classes="opportunity-subscription__popover">
 						<template #button="{ toggle }">
 							<span v-if="!agent" class="fakeInput" @click="toggle()">
 								<div class="fakeInput__img">
@@ -58,7 +58,7 @@ $this->import('
 					</select-entity>
 				</div>
 				<div class="col-6 sm:col-12 opportunity-subscription__selectAgents" v-if="selectAgentRelationColetivo">
-					<select-entity type="agent" openside="down-right" :query="{'type': 'EQ(2)'}" select="name,files.avatar,endereco,location,type" @fetch="fetch($event)" @select="selectAgent($event)" classes="opportunity-subscription__popover">
+					<select-entity type="agent" openside="down-right" :createNew="true" :create-new-type="2" :query="{'type': 'EQ(2)'}" select="name,files.avatar,endereco,location,type" @fetch="fetch($event)" @select="selectAgent($event)" classes="opportunity-subscription__popover">
 						<template #button="{ toggle }">
 							<span v-if="!agentCollective" class="fakeInput" @click="toggle()">
 								<div class="fakeInput__img">


### PR DESCRIPTION
## Objetivo

 Reaproveitando o modal padrão de create-agent a partir do select-entity, criar um fluxo para que o usuário não precise sair da página de inscrição na oportunidade.

## Abordagem

  - Ativei a ação Criar agente dentro dos select-entity usados na inscrição de oportunidade.
  - Fiz o modal de criação abrir fora do popover, com teleport="body", para evitar o layout
    apertado e a rolagem ruim dentro do seletor.
  - Ajustei o comportamento de fechamento para evitar conflitos com campos internos do
    formulário, textarea e multiselects/taxonomias.
  - Corrigi o mc-popover para não desmontar o fluxo quando o usuário interage com modais
    abertos fora dele.
  - Recarreguei automaticamente a lista de agentes após criar um novo agente.
  - Passei o tipo inicial do agente para o modal:
      - no seletor de agente individual, o modal abre com tipo individual;
      - no seletor de agente coletivo, o modal abre com tipo coletivo.

 ## Principais alterações

  - src/modules/Opportunities/components/opportunity-subscription/template.php
  - src/modules/Components/components/select-entity/template.php
  - src/modules/Components/components/select-entity/script.js
  - src/modules/Entities/components/create-agent/template.php
  - src/modules/Entities/components/create-agent/script.js
  - src/modules/Components/components/mc-popover/script.js