### PR TITLE
Feat/delivery extended fields minc

### DIFF
--- a/src/core/Entities/Registration.php
+++ b/src/core/Entities/Registration.php
@@ -1361,6 +1361,9 @@ class Registration extends \MapasCulturais\Entity
             $errorsResult['avatar'] = [sprintf(\MapasCulturais\i::__('A imagem avatar do agente "%s" é obrigatório.'),$this->owner->name)];
         }
 
+        $proponent_agent_relation = $this->opportunity->proponentAgentRelation ?? null;
+        $proponent_agent_relation_avatar = $this->opportunity->proponentAgentRelationAvatar ?? null;
+
         $definitionsWithAgents = $this->_getDefinitionsWithAgents();
         
         // validate agents
@@ -1395,6 +1398,17 @@ class Registration extends \MapasCulturais\Entity
             }
 
             if($def->agent){
+                $requires_avatar = false;
+                if ($proponent_agent_relation && $proponent_agent_relation_avatar) {
+                    $requires_avatar = ($proponent_agent_relation->{$this->proponentType} ?? false)
+                        && ($proponent_agent_relation_avatar->{$this->proponentType} ?? false);
+                }
+
+                if ($group_name === 'coletivo' && $requires_avatar && !array_key_exists('avatar', $def->agent->files)) {
+                    $errorsResult[$agent_prefix . $def->agentRelationGroupName . '_avatar'] = [
+                        sprintf(i::__('A imagem avatar do agente "%s" é obrigatório.'), $def->agent->name)
+                    ];
+                }
 
                 if($def->relationStatus < 0){
                     $errors[] = sprintf(i::__('O agente %s ainda não confirmou sua participação neste projeto.'), $def->agent->name);

--- a/src/modules/Entities/components/entity-profile/template.php
+++ b/src/modules/Entities/components/entity-profile/template.php
@@ -12,7 +12,7 @@ $this->import('
 ');
 ?>
 
-<div class="entity-profile">
+<div class="entity-profile" :class="{error: entity.__validationErrors?.['file:avatar']}">
     <mc-image-uploader :entity="entity" group="avatar" :aspect-ratio="1" :circular="true">
         <template #default="modal">
             <div class="entity-profile__profile">
@@ -24,4 +24,7 @@ $this->import('
             </div>
         </template>
     </mc-image-uploader>
+    <div v-if="entity.__validationErrors?.['file:avatar']" class="field__error">
+        {{entity.__validationErrors?.['file:avatar'].join(', ')}}
+    </div>
 </div>

--- a/src/modules/Opportunities/Module.php
+++ b/src/modules/Opportunities/Module.php
@@ -1073,6 +1073,12 @@ class Module extends \MapasCulturais\Module{
             'description' => i::__('Armazena se a vinculação de agente coletivo está habilitada para Coletivo ou Pessoa Jurídica'),
         ]);
 
+        $this->registerOpportunityMetadata('proponentAgentRelationAvatar', [
+            'label' => i::__('Solicitação de avatar do Agente coletivo para tipos de proponente'),
+            'type' => 'object',
+            'description' => i::__('Armazena se o avatar do agente coletivo é obrigatório para Coletivo ou Pessoa Jurídica'),
+        ]);
+
         $this->registerEvauationMethodConfigurationMetadata('fetchFields', [
             'label' => i::__('Configuração filtro de inscrição para avaliadores/comissão'),
             'type' => 'object',

--- a/src/modules/Opportunities/components/opportunity-proponent-types/script.js
+++ b/src/modules/Opportunities/components/opportunity-proponent-types/script.js
@@ -26,6 +26,10 @@ app.component('opportunity-proponent-types', {
                 "Coletivo": false,
                 "Pessoa Jurídica": false
             },
+            proponentAgentRelationAvatar: this.entity.proponentAgentRelationAvatar || {
+                "Coletivo": false,
+                "Pessoa Jurídica": false
+            },
         };
     },
 
@@ -51,6 +55,7 @@ app.component('opportunity-proponent-types', {
     
                 if (optionValue === 'Coletivo' || optionValue === 'Pessoa Jurídica') {
                     this.proponentAgentRelation[optionValue] = false;
+                    this.proponentAgentRelationAvatar[optionValue] = false;
                 }
             }
 
@@ -60,6 +65,17 @@ app.component('opportunity-proponent-types', {
 
         toggleAgentRelation(event, type) {
             this.proponentAgentRelation[type] = event.target.checked;
+
+            if (!event.target.checked) {
+                this.proponentAgentRelationAvatar[type] = false;
+            }
+
+            this.updateProponentAgentRelation();
+            this.entity.save();
+        },
+
+        toggleAgentRelationAvatar(event, type) {
+            this.proponentAgentRelationAvatar[type] = event.target.checked;
             this.updateProponentAgentRelation();
             this.entity.save();
         },
@@ -68,6 +84,7 @@ app.component('opportunity-proponent-types', {
             const anyAgentRelationChecked = Object.values(this.proponentAgentRelation).includes(true);
             this.entity.useAgentRelationColetivo = anyAgentRelationChecked ? 'required' : 'dontUse';
             this.entity.proponentAgentRelation = this.proponentAgentRelation;
+            this.entity.proponentAgentRelationAvatar = this.proponentAgentRelationAvatar;
         }
     }
 });

--- a/src/modules/Opportunities/components/opportunity-proponent-types/template.php
+++ b/src/modules/Opportunities/components/opportunity-proponent-types/template.php
@@ -38,7 +38,7 @@ use MapasCulturais\i;
                             :checked="proponentAgentRelationAvatar['Coletivo']" 
                             @change="toggleAgentRelationAvatar($event, 'Coletivo')"
                         > 
-                        <?= i::__("Obrigar o upload da foto de perfil")?>
+                        <?= i::__("Habilitar solicitação de imagem de perfil")?>
                     </label>
                 </div>
 
@@ -57,7 +57,7 @@ use MapasCulturais\i;
                             :checked="proponentAgentRelationAvatar['Pessoa Jurídica']" 
                             @change="toggleAgentRelationAvatar($event, 'Pessoa Jurídica')"
                         > 
-                        <?= i::__("Obrigar o upload da foto de perfil")?>
+                        <?= i::__("Habilitar solicitação de imagem de perfil")?>
                     </label>
                 </div>
             </div>

--- a/src/modules/Opportunities/components/opportunity-proponent-types/template.php
+++ b/src/modules/Opportunities/components/opportunity-proponent-types/template.php
@@ -32,6 +32,14 @@ use MapasCulturais\i;
                         > 
                         <?= i::__("Habilitar a vinculação de agente coletivo")?>
                     </label>
+                    <label v-if="proponentAgentRelation['Coletivo']">
+                        <input 
+                            type="checkbox" 
+                            :checked="proponentAgentRelationAvatar['Coletivo']" 
+                            @change="toggleAgentRelationAvatar($event, 'Coletivo')"
+                        > 
+                        <?= i::__("Obrigar o upload da foto de perfil")?>
+                    </label>
                 </div>
 
                 <div class="opportunity-proponent-types__field field__legal" v-if="showJuridicaBinding && optionValue === 'Pessoa Jurídica'">
@@ -42,6 +50,14 @@ use MapasCulturais\i;
                             @change="toggleAgentRelation($event, 'Pessoa Jurídica')"
                         > 
                         <?= i::__("Habilitar a vinculação de agente coletivo")?>
+                    </label>
+                    <label v-if="proponentAgentRelation['Pessoa Jurídica']">
+                        <input 
+                            type="checkbox" 
+                            :checked="proponentAgentRelationAvatar['Pessoa Jurídica']" 
+                            @change="toggleAgentRelationAvatar($event, 'Pessoa Jurídica')"
+                        > 
+                        <?= i::__("Obrigar o upload da foto de perfil")?>
                     </label>
                 </div>
             </div>

--- a/src/modules/Opportunities/components/registration-card/script.js
+++ b/src/modules/Opportunities/components/registration-card/script.js
@@ -45,6 +45,11 @@ app.component('registration-card', {
             }
             return status;
         },
+        collectiveName() {
+            return this.entity.agentRelations?.coletivo?.[0]?.agent?.name
+                || this.entity.agentRelations?.coletivo?.[0]?.agent?.nomeCompleto
+                || '';
+        },
     },
     
     methods: { 

--- a/src/modules/Opportunities/components/registration-card/template.php
+++ b/src/modules/Opportunities/components/registration-card/template.php
@@ -82,9 +82,9 @@ $this->import('
                 <?php endif ?>
 
                 <?php if($app->config['app.registrationCardFields']['coletive']): ?>
-                    <div v-if="entity?.agentRelations?.coletivo" class="registerData">
+                    <div v-if="collectiveName" class="registerData">
                         <p class="title"> <?= $this->text('coletive-label',i::__('Nome coletivo')) ?></p>
-                        <p class="data"> {{entity?.agentRelations?.coletivo[0].agent.nomeCompleto}} </p>
+                        <p class="data"> {{collectiveName}} </p>
                     </div>
                 <?php endif ?>
             </div>

--- a/src/modules/Opportunities/components/registration-edition/script.js
+++ b/src/modules/Opportunities/components/registration-edition/script.js
@@ -69,6 +69,12 @@ app.component('registration-edition', {
         step () {
             return this.steps[this.stepIndex];
         },
+
+        collectiveAvatarRequired() {
+            const avatarConfig = this.entity.opportunity.proponentAgentRelationAvatar ?? {};
+            const relationConfig = this.entity.opportunity.proponentAgentRelation ?? {};
+            return relationConfig[this.entity.proponentType] === true && avatarConfig[this.entity.proponentType] === true;
+        },
     },
 
     watch: {

--- a/src/modules/Opportunities/components/registration-edition/script.js
+++ b/src/modules/Opportunities/components/registration-edition/script.js
@@ -70,6 +70,28 @@ app.component('registration-edition', {
             return this.steps[this.stepIndex];
         },
 
+        collectiveRelations() {
+            const relations = this.entity.agentRelations.coletivo ?? [];
+
+            return relations.map((relation) => {
+                if (relation?.agent instanceof Entity) {
+                    return relation;
+                }
+
+                if (relation?.agent?.id) {
+                    const agent = new Entity('agent', relation.agent.id);
+                    agent.populate(relation.agent);
+
+                    return {
+                        ...relation,
+                        agent,
+                    };
+                }
+
+                return relation;
+            });
+        },
+
         collectiveAvatarRequired() {
             const avatarConfig = this.entity.opportunity.proponentAgentRelationAvatar ?? {};
             const relationConfig = this.entity.opportunity.proponentAgentRelation ?? {};

--- a/src/modules/Opportunities/components/registration-edition/template.php
+++ b/src/modules/Opportunities/components/registration-edition/template.php
@@ -59,8 +59,8 @@ $this->import('
                             </div>
                         </div>
                     </div>
-                    <div class="card collective" v-if="!preview && entity.agentRelations.coletivo?.length > 0">
-                        <div class="card__content" v-for="agentCollective in entity.agentRelations.coletivo">
+                    <div class="card collective" v-if="!preview && collectiveRelations.length > 0">
+                        <div class="card__content" v-for="agentCollective in collectiveRelations">
                             <div class="collective">
                                 <mc-avatar v-if="!collectiveAvatarRequired" :entity="agentCollective.agent" size="small"></mc-avatar>
                                 <request-agent-avatar

--- a/src/modules/Opportunities/components/registration-edition/template.php
+++ b/src/modules/Opportunities/components/registration-edition/template.php
@@ -62,7 +62,12 @@ $this->import('
                     <div class="card collective" v-if="!preview && entity.agentRelations.coletivo?.length > 0">
                         <div class="card__content" v-for="agentCollective in entity.agentRelations.coletivo">
                             <div class="collective">
-                                <mc-avatar :entity="agentCollective.agent" size="small"></mc-avatar>
+                                <mc-avatar v-if="!collectiveAvatarRequired" :entity="agentCollective.agent" size="small"></mc-avatar>
+                                <request-agent-avatar
+                                    v-if="collectiveAvatarRequired"
+                                    :entity="entity"
+                                    :agent="agentCollective.agent"
+                                    error-key="agent_coletivo_avatar"></request-agent-avatar>
                                 <div class="collective__content">
                                     <div class="collective__content--title">
                                         <h3 class="card__title">
@@ -71,6 +76,9 @@ $this->import('
                                         <div class="collective__name">
                                             {{agentCollective.agent.name}}
                                         </div>
+                                    </div>
+                                    <div v-if="collectiveAvatarRequired" class="card__mandatory">
+                                        <div class="obrigatory"> <?= i::__('*obrigatório') ?> </div>
                                     </div>
                                 </div>
                             </div>

--- a/src/modules/Opportunities/components/request-agent-avatar/script.js
+++ b/src/modules/Opportunities/components/request-agent-avatar/script.js
@@ -8,18 +8,39 @@ template: $TEMPLATES['request-agent-avatar'],
         return {}
     },
 
-    computed: {},
+    computed: {
+        targetEntity() {
+            return this.agent || this.entity.owner;
+        },
+
+        errorMessages() {
+            if (!this.errorKey) {
+                return [];
+            }
+
+            return this.entity.__validationErrors?.[this.errorKey] || [];
+        },
+    },
 
     props: {
         entity: {
             type: Entity,
             required: true
         },
+        agent: {
+            type: Entity,
+            required: false,
+            default: null
+        },
+        errorKey: {
+            type: String,
+            default: 'avatar'
+        }
     },
 
     methods: {
         hasErrors() {
-            let errors = this.entity.__validationErrors['avatar'] || [];
+            let errors = this.errorMessages;
             if(errors.length > 0){
                 return true;
             } else {

--- a/src/modules/Opportunities/components/request-agent-avatar/template.php
+++ b/src/modules/Opportunities/components/request-agent-avatar/template.php
@@ -13,5 +13,8 @@ $this->import('
 
 ?>
 <span class="icon">
-    <entity-profile :entity="entity.owner" size="small"></entity-profile>
+    <entity-profile :entity="targetEntity" size="small"></entity-profile>
 </span>
+<div v-if="errorMessages.length" class="field__error">
+    {{ errorMessages.join(', ') }}
+</div>

--- a/src/modules/OpportunityExporter/Exporter.php
+++ b/src/modules/OpportunityExporter/Exporter.php
@@ -1,0 +1,500 @@
+<?php
+
+namespace OpportunityExporter;
+
+use Exception;
+use MapasCulturais\Entities\File;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\App;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entity;
+
+class Exporter
+{
+    /**
+     * Leia o README.md do módulo
+     */
+    const VERSION = '1.0.0';
+
+    /**
+     * @param Opportunity $opportunity Oportunidade a ser exportada
+     * @param bool $infos Exportar informações básicas
+     * @param bool $files Exportar anexos
+     * @param bool $images Exportar imagens
+     * @param bool $dates Exportar datas das fases do edital
+     * @param bool $vacancyLimits Exportar limites de vagas
+     * @param bool $workplan Exportar plano de metas
+     * @param bool $statusLabels Exportar configurações de status
+     * @param bool $appealPhases Exportar fases de recurso
+     * @param bool $monitoringPhases Exportar fases de monitoramento
+     */
+    function __construct(
+        protected Opportunity $opportunity,
+        protected bool $infos = false,
+        protected bool $files = false,
+        protected bool $images = false,
+
+        protected bool $dates = false, // exportado a cada fase
+
+        protected bool $vacancyLimits = false,
+
+        protected bool $workplan = false,
+
+        protected bool $statusLabels = false, // exportado a cada fase
+        protected bool $appealPhases = false, // exportado a cada fase
+        protected bool $monitoringPhases = false,
+    ) {
+        if (!$opportunity->isFirstPhase) {
+            throw new Exception('O parâmetro opportunity deve ser a primeira fase de uma oportunidade');
+        }
+    }
+
+    public function export(): string
+    {
+        $app = App::i();
+
+        $result = [
+            'exporterVersion' => self::VERSION,
+            'entityType' => 'opportunity',
+            'exported' => [
+                'infos' => $this->infos,
+                'files' => $this->files,
+                'images' => $this->images,
+                'dates' => $this->dates,
+                'vacancyLimits' => $this->vacancyLimits,
+                'workplan' => $this->workplan,
+                'statusLabels' => $this->statusLabels,
+                'appealPhases' => $this->appealPhases,
+                'monitoringPhases' => $this->monitoringPhases,
+            ]
+        ];
+
+        if ($this->infos) {
+            $result['infos'] = $this->exportInfo();
+        }
+
+        if ($this->files) {
+            $registered_file_groups = $app->getRegisteredFileGroupsByEntity(Opportunity::class);
+            $result['files'] = [];
+            foreach ($registered_file_groups as $file_group) {
+                if (in_array($file_group->name, ['header', 'avatar', 'gallery'])) {
+                    continue;
+                }
+
+                $result['files'][$file_group->name] = $this->exportFileGroup($file_group->name);
+            }
+        }
+
+        if ($this->images) {
+            $result['images'] = [
+                'header' => $this->exportFileGroup('header'),
+                'avatar' => $this->exportFileGroup('avatar'),
+                'gallery' => $this->exportFileGroup('gallery'),
+            ];
+        }
+
+        if ($this->vacancyLimits) {
+            $result['vacancyLimits'] = $this->exportVacancyLimits();
+        }
+
+        $result['categories'] = $this->exportCategories();
+        $result['ranges'] = $this->exportRanges();
+        $result['proponentTypes'] = $this->exportProponentTypes();
+
+        if ($this->workplan) {
+            $result['workplan'] = $this->exportWorkplan();
+        }
+
+        $result['phases'] = [];
+
+        foreach ($this->opportunity->allPhases as $phase) {
+            if ($phase->isReportingPhase) {
+                if (!$this->monitoringPhases) {
+                    continue;
+                }
+                $result['phases'][] = $this->exportMonitoringPhase($phase);
+            } else {
+                $result['phases'][] = $this->exportPhase($phase);
+            }
+        }
+
+
+        return json_encode($result);
+    }
+
+    public function exportInfo(): array
+    {
+        $result = [];
+
+        $result['properties'] = $this->exportInfoProperties();
+        $result['metalists'] = $this->exportInfoMetalists();
+
+        return $result;
+    }
+
+    public function exportInfoProperties(): array
+    {
+        $result = [];
+
+        $properties = Module::getInfoProperties();
+
+        foreach ($properties as $prop) {
+            $result[$prop] = $this->opportunity->$prop;
+        }
+
+        $result['type'] = $result['type']->id;
+
+        return $result;
+    }
+
+    public function exportInfoMetalists(): array
+    {
+        $result = [];
+        foreach ($this->opportunity->metaLists as $group => $metalists) {
+            $result[$group] = [];
+
+            foreach ($metalists as $metalist) {
+                $result[$group][] = $metalist->simplify('title,value,description');
+            }
+        }
+        return $result;
+    }
+
+    public function exportVacancyLimits(): array
+    {
+        $result = [
+            'registrationLimit' => $this->opportunity->registrationLimit,
+            'registrationLimitPerOwner' => $this->opportunity->registrationLimitPerOwner,
+            'totalResource' => $this->opportunity->totalResource,
+            'vacancies' => $this->opportunity->vacancies,
+        ];
+
+        return $result;
+    }
+
+    public function exportCategories(): array
+    {
+        return $this->opportunity->registrationCategories ?: [];
+    }
+
+    public function exportRanges(): array
+    {
+        return $this->opportunity->registrationRanges ?: [];
+    }
+
+    public function exportProponentTypes(): array
+    {
+        $result = [
+            'registrationProponentTypes' => $this->opportunity->registrationProponentTypes ?: [],
+            'useAgentRelationColetivo' => $this->opportunity->useAgentRelationColetivo,
+            'proponentAgentRelation' => $this->opportunity->proponentAgentRelation,
+            'proponentAgentRelationAvatar' => $this->opportunity->proponentAgentRelationAvatar,
+        ];
+
+        return $result;
+    }
+
+    public function exportWorkplan(): array
+    {
+        if(!$this->opportunity->enableWorkplan) {
+            return ['enableWorkplan' => false];
+        }
+
+        $result = ['enableWorkplan' => true];
+
+        foreach(Module::getInfoProperties() as $prop) {
+            $result[$prop] = $this->opportunity->$prop;
+        }
+
+        return $result;
+    }
+
+    public function exportFile(File $file): array
+    {
+        if (file_exists($file->path)) {
+            $file_content = file_get_contents($file->path);
+        } else {
+            $file_content = '';
+        }
+
+        $result = [
+            'name' => $file->name,
+            'description' => $file->description,
+            'mimeType' => $file->mimeType,
+            'md5' => $file->md5,
+            'content' => base64_encode($file_content)
+        ];
+
+        return $result;
+    }
+
+    public function exportFileGroup(string $group_name, ?Entity $owner = null): array
+    {
+        $result = [];
+
+        if(is_null($owner)) {
+            $owner = $this->opportunity;
+        }
+
+        if ($group_files = $owner->files[$group_name] ?? false) {
+            $group_files = is_array($group_files) ? $group_files : [$group_files];
+
+            foreach ($group_files as $file) {
+                $result[] = $this->exportFile($file);
+            }
+        }
+
+        return $result;
+    }
+
+    // por fase
+
+    public function exportPhase(Opportunity $phase, array $include_metadata = []): array
+    {
+        $export_phase_props = [
+            'isDataCollection',
+            ...$include_metadata,
+        ];
+
+        if (!$phase->isFirstPhase) {
+            // o nome da primeira fase é exportado nas infos
+            $export_phase_props = [
+                ...$export_phase_props,
+                'name'
+            ];
+        }
+
+        if ($this->statusLabels) {
+            $export_phase_props = [
+                ...$export_phase_props,
+                'statusLabels'
+            ];
+        }
+
+        if ($this->dates) {
+            $export_phase_props = [
+                ...$export_phase_props,
+                'registrationFrom',
+                'registrationTo',
+                'publishTimestamp',
+                'autoPublish',
+            ];
+        }
+
+        $result = [];
+
+        if ($phase->isFirstPhase) {
+            $result['isFirstPhase'] = true;
+        }
+
+        if ($phase->isLastPhase) {
+            $result['isLastPhase'] = true;
+        }
+
+        foreach ($export_phase_props as $prop) {
+            $value = $phase->$prop;
+            if($value instanceof \DateTime) {
+                $value = $value->format('Y-m-d H:i:s');
+            }
+            $result[$prop] = $value;
+        }
+
+        if ($phase->isDataCollection) {
+            $result['form'] = $this->exportForm($phase);
+        }
+
+        if ($evaluation_phase = $phase->evaluationMethodConfiguration) {
+            $result['evaluationPhase'] = $this->exportEvaluationPhase($evaluation_phase);
+        }
+
+        if ($this->appealPhases) {
+            $result['appealPhase'] = $this->exportAppealPhase($phase);
+        }
+
+        return $result;
+    }
+
+    public function exportForm(Opportunity $phase): array
+    {
+        $result = [
+            'steps' => $this->exportFormSteps($phase),
+            'fields' => $this->exportFormFields($phase),
+            'attachments' => $this->exportFormAttachments($phase)
+        ];
+
+        return $result;
+    }
+
+    public function exportFormSteps(Opportunity $phase): array
+    {
+        $result = [];
+
+        foreach ($phase->registrationSteps as $step) {
+            $step_id = "STEP(" . base_convert($step->id, 10, 36) . ")";
+
+            $result[$step_id] = [
+                'name' => $step->name,
+                'displayOrder' => $step->displayOrder,
+                'metadata' => $step->metadata
+            ];
+        }
+
+        return $result;
+    }
+
+    public function exportFormFields(Opportunity $phase): array
+    {
+        $result = [];
+
+        foreach ($phase->registrationFieldConfigurations as $field) {
+            $field_id = "FIELD(" . base_convert($field->id, 10, 36) . ")";
+
+            $config = is_array($field->config) ? array_filter($field->config) : $field->config;
+
+            $field_result = [
+                'step' => "STEP(" . base_convert($field->step->id, 10, 36) . ")",
+
+                'title' => $field->title,
+                'description' => $field->description,
+                'maxSize' => $field->maxSize,
+                'required' => $field->required,
+                'fieldType' => $field->fieldType,
+                'displayOrder' => $field->displayOrder,
+                'fieldOptions' => $field->fieldOptions,
+                'config' => $config,
+                'categories' => $field->categories,
+                'registrationRanges' => $field->registrationRanges,
+                'proponentTypes' => $field->proponentTypes,
+
+                'conditional' => false,
+            ];
+
+            if ($field->conditional && $field->conditionalField && preg_match('#field_(\d+)#', $field->conditionalField, $matches)) {
+                $conditional_field = "FIELD(" . base_convert($matches[1], 10, 36) . ")";
+                $field_result = [
+                    ...$field_result,
+                    'conditional' => true,
+                    'conditionalField' => "$conditional_field",
+                    'conditionalValue' => $field->conditionalValue,
+                ];
+            }
+
+            $result[$field_id] = $field_result;
+        }
+
+        return $result;
+    }
+
+    public function exportFormAttachments(Opportunity $phase): array
+    {
+        $result = [];
+
+        foreach ($phase->registrationFileConfigurations as $rfc) {
+            $rfc_id = "FILE(" . base_convert($rfc->id, 10, 36) . ")";
+
+            $rfc_result = [
+                'step' => "STEP(" . base_convert($rfc->step->id, 10, 36) . ")",
+
+                'title' => $rfc->title,
+                'description' => $rfc->description,
+                'required' => $rfc->required,
+                'displayOrder' => $rfc->displayOrder,
+                'categories' => $rfc->categories,
+                'registrationRanges' => $rfc->registrationRanges,
+                'proponentTypes' => $rfc->proponentTypes,
+
+                'conditional' => false,
+            ];
+
+            if ($rfc->conditional && $rfc->conditionalField && preg_match('#field_(\d+)#', $rfc->conditionalField, $matches)) {
+                $conditional_field = "FIELD(" . base_convert($matches[1], 10, 36) . ")";
+                $rfc_result = [
+                    ...$rfc_result,
+                    'conditional' => true,
+                    'conditionalField' => "$conditional_field",
+                    'conditionalValue' => $rfc->conditionalValue,
+                ];
+            }
+
+            if ($template = $rfc->files['registrationFileTemplate'] ?? false) {
+                $rfc_result['template'] = $this->exportFile($template);
+            }
+
+            $result[$rfc_id] = $rfc_result;
+        }
+
+        return $result;
+    }
+
+    public function exportEvaluationPhase(EvaluationMethodConfiguration $phase): array
+    {
+        $result = $phase->evaluationMethod->export($phase);
+
+        $result = [
+            'name' => $phase->name,
+            'type' => $phase->type->id,
+            'evaluationFrom' => $phase->evaluationFrom ? $phase->evaluationFrom->format('Y-m-d H:i:s') : null,
+            'evaluationTo' => $phase->evaluationTo ? $phase->evaluationTo->format('Y-m-d H:i:s') : null,
+
+            ...$result,
+
+            'infos' => $phase->infos,
+            'publishEvaluationDetails' => $phase->publishEvaluationDetails,
+            'publishValuerNames' => $phase->publishValuerNames,
+            'autoApplicationAllowed' => $phase->autoApplicationAllowed,
+
+            'avaliableEvaluationFields' => $phase->opportunity->avaliableEvaluationFields,
+        ];
+
+        $result_json = json_encode($result);
+
+        if (preg_match_all('#field_(\d+)#', $result_json, $matches)) {
+            foreach ($matches[0] as $i => $field_name) {
+                $fid = "FIELD(" . base_convert($matches[1][$i], 10, 36) . ")";
+                $result_json = str_replace($field_name, ":$fid", $result_json);
+            }
+        }
+
+        if (preg_match_all('#"field":"?(\d+)"?#', $result_json, $matches)) {
+            foreach ($matches[0] as $i => $field_name) {
+                $fid = "FIELD(" . base_convert($matches[1][$i], 10, 36) . ")";
+                $result_json = str_replace($field_name, "\"field\":\"@$fid\"", $result_json);
+            }
+        }
+
+        if (preg_match_all('#rfc_(\d+)#', $result_json, $matches)) {
+            foreach ($matches[0] as $i => $file_group) {
+                $fid = "FILE(" . base_convert($matches[1][$i], 10, 36) . ")";
+                $result_json = str_replace($file_group, "%$fid", $result_json);
+            }
+        }
+
+        return (array) json_decode($result_json);
+    }
+
+    public function exportAppealPhase(Opportunity $phase): ?array
+    {
+        $appeal_phase = $phase->appealPhase;
+
+        if (!$appeal_phase) {
+            return null;
+        }
+
+        $result = $this->exportPhase($appeal_phase, ['isAppealPhase']);
+
+        return $result;
+    }
+
+    public function exportMonitoringPhase(Opportunity $phase): ?array
+    {
+        $result = [];
+
+        if (!$phase->isReportingPhase) {
+            return null;
+        }
+
+        $result = $this->exportPhase($phase, ['isReportingPhase', 'isFinalReportingPhase', 'includesWorkPlan']);
+
+        return $result;
+    }
+}

--- a/src/modules/OpportunityExporter/Importer.php
+++ b/src/modules/OpportunityExporter/Importer.php
@@ -1,0 +1,457 @@
+<?php
+
+namespace OpportunityExporter;
+
+use Exception;
+use MapasCulturais\Entities\File;
+use MapasCulturais\Entities;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\App;
+use MapasCulturais\Entities\Agent;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
+use MapasCulturais\Entities\Event;
+use MapasCulturais\Entities\MetaList;
+use MapasCulturais\Entities\Project;
+use MapasCulturais\Entities\RegistrationFieldConfiguration;
+use MapasCulturais\Entities\RegistrationFileConfiguration;
+use MapasCulturais\Entities\RegistrationStep;
+use MapasCulturais\Entities\Space;
+use MapasCulturais\Entity;
+
+class Importer
+{
+    /**
+     * Leia o README.md do módulo
+     */
+    const VERSION = '1.0.0';
+
+    protected Opportunity $opportunity;
+
+    /**
+     * Mapeamento dos steps criados
+     * @var RegistrationStep[]
+     */
+    protected array $stepsMap = [];
+
+    /**
+     * Mapeamento dos fields criados
+     * @var RegistrationFieldConfiguration[]
+     */
+    protected array $fieldsMap = [];
+
+    /**
+     * Mapeamento dos anexos criados
+     * @var RegistrationFileConfiguration[]
+     */
+    protected array $attachmentsMap = [];
+
+    public function __construct(
+        protected Agent|Space|Event|Project $onwerEntity,
+        protected array $data,
+
+        protected bool $files = false,
+        protected bool $images = false,
+
+        protected bool $dates = false, // exportado a cada fase
+
+        protected bool $vacancyLimits = false,
+
+        protected bool $workplan = false,
+
+        protected bool $statusLabels = false, // exportado a cada fase
+        protected bool $appealPhases = false, // exportado a cada fase
+        protected bool $monitoringPhases = false,
+    ) {
+        $opportunity_class = $this->onwerEntity->opportunityClassName;
+
+        $opportunity = new $opportunity_class;
+        $opportunity->ownerEntity = $this->onwerEntity;
+
+        $this->opportunity = $opportunity;
+    }
+
+    public function import(): Opportunity
+    {
+        $data = $this->data;
+        $this->importInfos($data['infos']);
+
+        if($this->files) {
+            foreach(($data['files'] ?? []) as $group => $files_data) {
+                $this->importFileGroup($group, $files_data);
+            }
+        }
+        
+        if($this->images) {
+            foreach(($data['images'] ?? []) as $group => $files_data) {
+                $this->importFileGroup($group, $files_data);
+            }
+        }
+
+        if ($this->vacancyLimits && isset($data['vacancyLimits'])) {
+            $this->importVacancyLimits($data['vacancyLimits']);
+        }
+
+        $this->importCategories($data['categories']);
+        $this->importRanges($data['ranges']);
+        $this->importProponentTypes($data['proponentTypes']);
+
+        if ($this->workplan && isset($data['workplan'])) {
+            $this->importWorkplan($data['workplan']);
+        }
+
+        foreach ($data['phases'] as $phase_data) {
+            if ($phase_data['isReportingPhase'] ?? false) {
+                $this->importMonitoringPhase($phase_data);
+            } else {
+                $this->importPhase($phase_data);
+            }
+        }
+
+        return $this->opportunity;
+    }
+
+    public function importInfos(array $data)
+    {
+        $this->importInfoProperties($data['properties']);
+
+        $this->importInfoProperties($data['metalists']);
+    }
+
+    public function importInfoProperties(array $data)
+    {
+        $properties = Module::getInfoProperties();
+
+        foreach ($properties as $prop) {
+            if (array_key_exists($prop, $data)) {
+                $this->opportunity->$prop = $data[$prop];
+            }
+        }
+
+        $this->opportunity->save(true);
+    }
+
+    public function exportInfoMetalists(array $data)
+    {
+        foreach ($data as $group => $metalists) {
+            foreach ($metalists as $val) {
+                $metalist = new MetaList;
+                $metalist->owner = $this->opportunity;
+                $metalist->group = $group;
+                $metalist->title = $val['title'];
+                $metalist->value = $val['value'];
+                $metalist->description = $val['description'];
+                $metalist->save(true);
+            }
+        }
+    }
+
+    public function importVacancyLimits(array $data)
+    {
+        $this->opportunity->registrationLimit = $data['registrationLimit'];
+        $this->opportunity->registrationLimitPerOwner = $data['registrationLimitPerOwner'];
+        $this->opportunity->totalResource = $data['totalResource'];
+        $this->opportunity->vacancies = $data['vacancies'];
+        $this->opportunity->save(true);
+    }
+
+    public function importCategories(array $data)
+    {
+        $this->opportunity->registrationCategories = $data ?? [];
+        $this->opportunity->save(true);
+    }
+
+    public function importRanges(array $data)
+    {
+        $this->opportunity->registrationRanges = $data ?? [];
+        $this->opportunity->save(true);
+    }
+
+    public function importProponentTypes(array $data)
+    {
+        $this->opportunity->registrationProponentTypes = $data['registrationProponentTypes'] ?? [];
+
+        if (array_key_exists('useAgentRelationColetivo', $data)) {
+            $this->opportunity->useAgentRelationColetivo = $data['useAgentRelationColetivo'];
+        }
+
+        if (array_key_exists('proponentAgentRelation', $data)) {
+            $this->opportunity->proponentAgentRelation = $data['proponentAgentRelation'];
+        }
+
+        if (array_key_exists('proponentAgentRelationAvatar', $data)) {
+            $this->opportunity->proponentAgentRelationAvatar = $data['proponentAgentRelationAvatar'];
+        }
+
+        $this->opportunity->save(true);
+    }
+
+    public function importWorkplan(array $data)
+    {
+        if ($data['enableWorkplan'] ?? false) {
+            $this->opportunity->enableWorkplan = true;
+
+            foreach (Module::getInfoProperties() as $prop) {
+                if (array_key_exists($prop, $data)) {
+                    $this->opportunity->$prop = $data[$prop];
+                }
+            }
+
+            $this->opportunity->save(true);
+        }
+    }
+
+    public function importPhase(array $phase_data, array $include_metadata = [], int $status = Opportunity::STATUS_PHASE, ?Opportunity $parent = null): Opportunity
+    {
+        if ($phase_data['isFirstPhase'] ?? false) {
+            $phase = $this->opportunity;
+        } else if ($phase_data['isLastPhase'] ?? false) {
+            $phase = $this->opportunity->lastPhase;
+        } else {
+            $opportunity_class = $this->onwerEntity->opportunityClassName;
+            $parent = $parent ?: $this->opportunity;
+
+            $phase = new $opportunity_class;
+            $phase->parent = $parent;
+            $phase->ownerEntity = $this->onwerEntity;
+            $phase->status = $status;
+            $phase->name = $phase_data['name'] ?? '';
+            $phase->registrationCategories = $parent->registrationCategories;
+            $phase->registrationRanges = $parent->registrationRanges;
+            $phase->registrationProponentTypes = $parent->registrationProponentTypes;
+            $phase->save(true);
+        }
+
+        /** @var Opportunity $phase */
+
+        $import_phase_props = [
+            'isDataCollection',
+            ...$include_metadata,
+        ];
+
+        if ($this->statusLabels) {
+            $import_phase_props = [
+                ...$import_phase_props,
+                'statusLabels'
+            ];
+        }
+
+        if ($this->dates) {
+            $import_phase_props = [
+                ...$import_phase_props,
+                'registrationFrom',
+                'registrationTo',
+                'publishTimestamp',
+                'autoPublish',
+            ];
+        }
+
+        foreach ($import_phase_props as $prop) {
+            if (array_key_exists($prop, $phase_data)) {
+                $phase->$prop = $phase_data[$prop];
+            }
+        }
+
+        $phase->save(true);
+
+        if ($phase->isDataCollection && array_key_exists('form', $phase_data)) {
+            $this->importForm($phase, $phase_data['form']);
+        }
+
+        if (array_key_exists('evaluationPhase', $phase_data)) {
+            $this->importEvaluationPhase($phase, $phase_data['evaluationPhase']);
+        }
+
+        $phase = $phase->refreshed();
+        if ($appeal_phase = $phase_data['appealPhase'] ?? null) {
+            $this->importAppealPhase($phase, $appeal_phase);
+        }
+
+        return $phase;
+    }
+
+    public function importMonitoringPhase(array $phase_data)
+    {
+        $this->importPhase($phase_data, ['isReportingPhase', 'isFinalReportingPhase', 'includesWorkPlan']);
+    }
+
+    public function importEvaluationPhase(Opportunity $phase, array $data): EvaluationMethodConfiguration
+    {
+
+        $data_json = json_encode($data);
+
+        foreach($this->fieldsMap as $fid => $field) {
+            $data_json = str_replace(":$fid", $field->fieldName, $data_json);
+            $data_json = str_replace('"field":"@' . $fid . '"', '"field":"' . $field->id . '"', $data_json);
+        }
+
+        foreach($this->attachmentsMap as $fid => $field) {
+            $data_json = str_replace("%$fid", $field->fileGroupName, $data_json);
+        }
+        
+        $replaced_data = json_decode($data_json, JSON_OBJECT_AS_ARRAY);
+
+        $evaluation_phase = new EvaluationMethodConfiguration;
+
+        $evaluation_phase->opportunity = $phase;
+        $evaluation_phase->name = $replaced_data['name'];
+        $evaluation_phase->type = $replaced_data['type'];
+        $evaluation_phase->evaluationFrom = $replaced_data['evaluationFrom'];
+        $evaluation_phase->evaluationTo = $replaced_data['evaluationTo'];
+        $evaluation_phase->save(true);
+
+        $evaluation_phase->evaluationMethod->import($evaluation_phase, $replaced_data);
+        $evaluation_phase->save(true);
+
+        return $evaluation_phase;
+    }
+
+    public function importAppealPhase(Opportunity $phase, array $data): Opportunity
+    {
+        $appeal_phase = $this->importPhase(
+            phase_data: $data, 
+            include_metadata: ['isAppealPhase'],
+            status: Opportunity::STATUS_APPEAL_PHASE,
+            parent: $phase
+        );
+
+        $phase->appealPhase = $appeal_phase;
+        $phase->save(true);
+
+        return $appeal_phase;
+    }
+
+    public function importForm(Opportunity $phase, array $data)
+    {
+        $this->importFormSteps($phase, $data['steps'] ?? []);
+        $this->importFormFields($phase, $data['fields'] ?? []);
+        $this->importFormAttachments($phase, $data['attachments'] ?? []);
+    }
+
+    public function importFormSteps(Opportunity $phase, array $data)
+    {
+        $app = App::i();
+        $app->conn->delete('registration_step', ['opportunity_id' => $phase->id]);
+        foreach ($data as $id => $step_data) {
+            $step = new RegistrationStep;
+            $step->opportunity = $phase;
+            $step->name = $step_data['name'] ?? '';
+            $step->displayOrder = $step_data['displayOrder'] ?? 0;
+            $step->metadata = $step_data['metadata'] ?? (object) [];
+            $step->save(true);
+
+            $this->stepsMap[$id] = $step;
+        }
+    }
+
+    public function importFormFields(Opportunity $phase, array $data)
+    {
+        $next_round = [];
+        foreach ($data as $id => $field_data) {
+            $conditional = $field_data['conditional'] ?? false;
+            $conditional_field = $field_data['conditionalField'] ?? null;
+
+            if ($conditional && $conditional_field && !isset($this->fieldsMap[$conditional_field])) {
+                $next_round[$id] = $field_data;
+                continue;
+            }
+
+            $field = new RegistrationFieldConfiguration;
+            $field->owner = $phase;
+            $field->step = $this->stepsMap[$field_data['step']];
+
+            $field->title = $field_data['title'];
+            $field->description = $field_data['description'];
+            $field->maxSize = $field_data['maxSize'];
+            $field->required = $field_data['required'];
+            $field->fieldType = $field_data['fieldType'];
+            $field->displayOrder = $field_data['displayOrder'];
+            $field->fieldOptions = $field_data['fieldOptions'];
+            $field->config = $field_data['config'];
+            $field->categories = $field_data['categories'];
+            $field->registrationRanges = $field_data['registrationRanges'];
+            $field->proponentTypes = $field_data['proponentTypes'];
+            $field->conditional = $conditional;
+
+            if ($field->conditional && $conditional_field) {
+                $field->conditionalField = $this->fieldsMap[$conditional_field]->fieldName;
+                $field->conditionalValue = $field_data['conditionalValue'];
+            }
+
+            $field->save(true);
+
+            $this->fieldsMap[$id] = $field;
+        }
+
+        if ($next_round) {
+            $this->importFormFields($phase, $next_round);
+        }
+    }
+
+    public function importFormAttachments(Opportunity $phase, array $data)
+    {
+        foreach ($data as $id => $rfc_data) {
+            $conditional = $rfc_data['conditional'] ?? false;
+            $conditional_field = $rfc_data['conditionalField'] ?? null;
+
+            $rfc = new RegistrationFileConfiguration;
+            $rfc->owner = $phase;
+            $rfc->step = $this->stepsMap[$rfc_data['step']];
+
+            $rfc->title = $rfc_data['title'];
+            $rfc->description = $rfc_data['description'];
+            $rfc->required = $rfc_data['required'];
+            $rfc->displayOrder = $rfc_data['displayOrder'];
+            $rfc->categories = $rfc_data['categories'];
+            $rfc->registrationRanges = $rfc_data['registrationRanges'];
+            $rfc->proponentTypes = $rfc_data['proponentTypes'];
+            $rfc->conditional = $conditional;
+
+            if ($rfc->conditional && $conditional_field) {
+                $rfc->conditionalField = $this->fieldsMap[$conditional_field]->fieldName;
+                $rfc->conditionalValue = $rfc_data['conditionalValue'];
+            }
+
+            $rfc->save(true);
+
+            $this->attachmentsMap[$id] = $rfc;
+
+
+            if ($template_file_data = $rfc_data['template'] ?? null) {
+                $this->importFile($rfc, 'registrationFileTemplate', $template_file_data);
+            }
+        }
+    }
+
+    public function importFileGroup(string $group, array $files_data, ?Entity $owner = null)
+    {
+        if(is_null($owner)) {
+            $owner = $this->opportunity;
+        }
+
+        foreach($files_data as $file_data) {
+            $this->importFile($owner, $group, $file_data);
+        }
+    }
+
+    public function importFile(Opportunity|EvaluationMethodConfiguration|RegistrationFileConfiguration $owner, string $group, array $file_data)
+    {
+        $tmp_filename = sys_get_temp_dir() . '/' . uniqid('importer-');
+        file_put_contents($tmp_filename, base64_decode($file_data['content']));
+
+        $file_class = $owner->fileClassName;
+
+        /** @var File */
+        $file = new $file_class([
+            'name' => $file_data['name'],
+            'tmp_name' => $tmp_filename,
+            'error' => UPLOAD_ERR_OK
+        ]);
+
+        $file->owner = $owner;
+        $file->name = $file_data['name'];
+        $file->description = $file_data['description'];
+        $file->group = $group;
+
+        $file->save(true);
+    }
+}

--- a/src/modules/OpportunityWorkplan/Module.php
+++ b/src/modules/OpportunityWorkplan/Module.php
@@ -152,7 +152,7 @@ class Module extends \MapasCulturais\Module{
                                     ];
 
                                     foreach ($simple_fields as $field) {
-                                        if ($delivery->isMetadataRequired($field) && !$delivery->$field) {
+                                        if ($delivery->isMetadataRequired($field) && !self::validateSelectField($delivery, $field)) {
                                             $label = self::getFieldLabel($field);
                                             $errors['delivery'][] = i::__("Campo '{$label}' obrigatório na entrega '{$delivery->name}'");
                                         }

--- a/src/modules/OpportunityWorkplan/components/registration-details-workplan/template.php
+++ b/src/modules/OpportunityWorkplan/components/registration-details-workplan/template.php
@@ -139,7 +139,7 @@ $this->import('
                     {{ delivery.artChainLink }}
                 </div>
 
-                <div v-if="opportunity.workplan_deliveryInformTotalBudget && delivery.totalBudget" class="field">
+                <div v-if="opportunity.workplan_deliveryInformTotalBudget && delivery.totalBudget !== null && delivery.totalBudget !== ''" class="field">
                     <label><?= i::esc_attr__('Orçamento total') ?></label>
                     {{ convertToCurrency(delivery.totalBudget) }}
                 </div>
@@ -173,7 +173,7 @@ $this->import('
                         <label><?= i::esc_attr__('Unidades para comercialização') ?></label>
                         {{ delivery.commercialUnits }}
                     </div>
-                    <div v-if="delivery.unitPrice" class="field">
+                    <div v-if="delivery.unitPrice !== null && delivery.unitPrice !== ''" class="field">
                         <label><?= i::esc_attr__('Valor unitário previsto') ?></label>
                         {{ convertToCurrency(delivery.unitPrice) }}
                     </div>

--- a/src/modules/OpportunityWorkplan/components/registration-workplan-form-delivery/template.php
+++ b/src/modules/OpportunityWorkplan/components/registration-workplan-form-delivery/template.php
@@ -187,7 +187,7 @@ $this->import('
 
         <div class="field" v-if="opportunity.workplan_monitoringInformCommercialUnits && (editable || proxy.executedUnitPrice)">
             <label :for="`${vid}__executedUnitPrice`"><?= i::__('Valor unitário praticado (R$)') ?><span v-if="opportunity.workplan_monitoringRequireUnitPrice" class="required">obrigatório*</span></label>
-            <div v-if="delivery.unitPrice" class="field__note">
+            <div v-if="delivery.unitPrice !== null && delivery.unitPrice !== ''" class="field__note">
                 <strong><?= i::__('Previsto:') ?></strong> {{ convertToCurrency(delivery.unitPrice) }}
             </div>
             <input v-if="editable" :id="`${vid}__executedUnitPrice`" type="number" v-model.number="proxy.executedUnitPrice" min="0" step="0.01">

--- a/src/modules/OpportunityWorkplan/components/registration-workplan/script.js
+++ b/src/modules/OpportunityWorkplan/components/registration-workplan/script.js
@@ -209,12 +209,12 @@ app.component('registration-workplan', {
                     if (!('monthInitial' in delivery)) delivery.monthInitial = null;
                     if (!('monthEnd' in delivery)) delivery.monthEnd = null;
                     if (!('artChainLink' in delivery)) delivery.artChainLink = null;
-                    if (!('totalBudget' in delivery)) delivery.totalBudget = null;
+                    if (!('totalBudget' in delivery)) delivery.totalBudget = '';
                     if (!('numberOfCities' in delivery)) delivery.numberOfCities = null;
                     if (!('numberOfNeighborhoods' in delivery)) delivery.numberOfNeighborhoods = null;
                     if (!('mediationActions' in delivery)) delivery.mediationActions = null;
                     if (!('commercialUnits' in delivery)) delivery.commercialUnits = null;
-                    if (!('unitPrice' in delivery)) delivery.unitPrice = null;
+                    if (!('unitPrice' in delivery)) delivery.unitPrice = '';
                     if (!('hasCommunityCoauthors' in delivery)) delivery.hasCommunityCoauthors = null;
                     if (!('communityCoauthorsDetail' in delivery)) delivery.communityCoauthorsDetail = null;
                     if (!('hasTransInclusionStrategy' in delivery)) delivery.hasTransInclusionStrategy = null;
@@ -294,7 +294,7 @@ app.component('registration-workplan', {
 
             // Novos campos de planejamento
             entityDelivery.artChainLink = null;
-            entityDelivery.totalBudget = null;
+            entityDelivery.totalBudget = '';
             entityDelivery.numberOfCities = null;
             entityDelivery.numberOfNeighborhoods = null;
             entityDelivery.mediationActions = null;
@@ -318,7 +318,7 @@ app.component('registration-workplan', {
             };
             entityDelivery.revenueType = [];
             entityDelivery.commercialUnits = null;
-            entityDelivery.unitPrice = null;
+            entityDelivery.unitPrice = '';
             entityDelivery.hasCommunityCoauthors = null;
             entityDelivery.communityCoauthorsDetail = null;
             entityDelivery.hasTransInclusionStrategy = null;
@@ -447,7 +447,7 @@ app.component('registration-workplan', {
 
                 // Novos campos configuráveis
                 if (this.opportunity.workplan_deliveryInformArtChainLink && this.opportunity.workplan_deliveryRequireArtChainLink && !delivery.artChainLink) emptyFields.push("Principal elo das artes acionado");
-                if (this.opportunity.workplan_deliveryInformTotalBudget && this.opportunity.workplan_deliveryRequireTotalBudget && !delivery.totalBudget) emptyFields.push("Orçamento total da atividade");
+                if (this.opportunity.workplan_deliveryInformTotalBudget && this.opportunity.workplan_deliveryRequireTotalBudget && (delivery.totalBudget === null || delivery.totalBudget === '')) emptyFields.push("Orçamento total da atividade");
                 if (this.opportunity.workplan_deliveryInformNumberOfCities && this.opportunity.workplan_deliveryRequireNumberOfCities && (delivery.numberOfCities === null || delivery.numberOfCities === '')) emptyFields.push("Número de municípios");
                 if (this.opportunity.workplan_deliveryInformNumberOfNeighborhoods && this.opportunity.workplan_deliveryRequireNumberOfNeighborhoods && (delivery.numberOfNeighborhoods === null || delivery.numberOfNeighborhoods === '')) emptyFields.push("Número de bairros");
                 if (this.opportunity.workplan_deliveryInformMediationActions && this.opportunity.workplan_deliveryRequireMediationActions && (delivery.mediationActions === null || delivery.mediationActions === '')) emptyFields.push("Ações de mediação/formação de público");
@@ -476,7 +476,7 @@ app.component('registration-workplan', {
                 if (this.opportunity.workplan_deliveryInformTeamComposition && this.opportunity.workplan_deliveryRequireTeamCompositionRace && (!delivery.teamCompositionRace || !this.calculateRaceTotal(delivery.teamCompositionRace))) emptyFields.push("Composição da equipe por raça/cor");
                 if (this.opportunity.workplan_deliveryInformRevenueType && this.opportunity.workplan_deliveryRequireRevenueType && (!Array.isArray(delivery.revenueType) || !delivery.revenueType.length)) emptyFields.push("Tipo de receita previsto");
                 if (this.opportunity.workplan_deliveryInformCommercialUnits && this.opportunity.workplan_deliveryRequireCommercialUnits && (delivery.commercialUnits === null || delivery.commercialUnits === '')) emptyFields.push("Quantidade de unidades para comercialização");
-                if (this.opportunity.workplan_deliveryInformCommercialUnits && this.opportunity.workplan_deliveryRequireUnitPrice && !delivery.unitPrice) emptyFields.push("Valor unitário previsto");
+                if (this.opportunity.workplan_deliveryInformCommercialUnits && this.opportunity.workplan_deliveryRequireUnitPrice && (delivery.unitPrice === null || delivery.unitPrice === '')) emptyFields.push("Valor unitário previsto");
                 if (this.opportunity.workplan_deliveryInformCommunityCoauthors && !delivery.hasCommunityCoauthors) emptyFields.push("Envolvimento de comunidades como coautores");
                 if (this.opportunity.workplan_deliveryInformCommunityCoauthors && delivery.hasCommunityCoauthors === 'true' && this.opportunity.workplan_deliveryRequireCommunityCoauthorsDetail && !delivery.communityCoauthorsDetail) emptyFields.push("Detalhamento do envolvimento de comunidades");
                 if (this.opportunity.workplan_deliveryInformTransInclusion && !delivery.hasTransInclusionStrategy) emptyFields.push("Estratégia de inclusão Trans/Travestis");

--- a/tests/src/OpportunityWorkplanRequireFieldsTest.php
+++ b/tests/src/OpportunityWorkplanRequireFieldsTest.php
@@ -5,7 +5,6 @@ use MapasCulturais\App;
 use OpportunityWorkplan\Entities\Workplan;
 use OpportunityWorkplan\Entities\Goal;
 use OpportunityWorkplan\Entities\Delivery;
-use Tests\Abstract\TestCase;
 use Tests\Traits\UserDirector;
 use Tests\Traits\OpportunityDirector;
 use Tests\Traits\RegistrationDirector;
@@ -16,7 +15,7 @@ use Tests\Traits\RegistrationDirector;
  * Execução:
  * docker exec -it mapas-dev-mapas vendor/bin/phpunit tests/src/OpportunityWorkplanRequireFieldsTest.php
  */
-class OpportunityWorkplanRequireFieldsTest extends TestCase
+class OpportunityWorkplanRequireFieldsTest extends \MapasCulturais_TestCase
 {
     use UserDirector;
     use OpportunityDirector;
@@ -214,6 +213,38 @@ class OpportunityWorkplanRequireFieldsTest extends TestCase
         $this->assertTrue($hasError, 'Título obrigatório vazio deveria gerar erro');
     }
 
+    /**
+     * Testa campos monetários obrigatórios aceitam zero como preenchido
+     */
+    public function testRequiredMoneyFieldsAcceptZero()
+    {
+        $user = $this->userDirector->createUser();
+        $this->login($user);
+
+        $opportunity = $this->createOpportunityWithWorkplan([
+            'workplan_deliveryInformTotalBudget' => true,
+            'workplan_deliveryRequireTotalBudget' => true,
+            'workplan_deliveryInformCommercialUnits' => true,
+            'workplan_deliveryRequireUnitPrice' => true,
+            'workplan_deliveryRequireCommercialUnits' => false,
+        ]);
+
+        $registration = $this->createRegistrationWithWorkplan($opportunity, $user, [
+            'delivery' => [
+                'totalBudget' => 0,
+                'commercialUnits' => 0,
+                'unitPrice' => 0,
+            ]
+        ]);
+
+        $errors = $this->collectSendValidationErrors($registration);
+        $deliveryErrors = $errors['delivery'] ?? [];
+        $deliveryErrorsText = implode(' | ', $deliveryErrors);
+
+        $this->assertStringNotContainsString('Orçamento total', $deliveryErrorsText, $deliveryErrorsText);
+        $this->assertStringNotContainsString('Valor unitário', $deliveryErrorsText, $deliveryErrorsText);
+    }
+
     // =====================================
     // MÉTODOS AUXILIARES
     // =====================================
@@ -307,5 +338,13 @@ class OpportunityWorkplanRequireFieldsTest extends TestCase
         $delivery->save(true);
 
         return $registration;
+    }
+
+    private function collectSendValidationErrors($registration): array
+    {
+        $errors = [];
+        $this->app->applyHookBoundTo($registration, 'entity(Registration).sendValidationErrors', [&$errors]);
+
+        return $errors;
     }
 }


### PR DESCRIPTION
## 🎯 Objetivo

Evoluir o módulo de Plano de Trabalho para suportar de forma estruturada a **execução (delivery)** das atividades, garantindo consistência entre os dados planejados e os dados executados, além de viabilizar validação, acompanhamento e uso futuro em monitoramento e analytics.

## 🧠 Abordagem

* Implementar **paridade entre planejamento e execução**, introduzindo campos `executed*` como contraparte direta dos campos existentes
* Utilizar flags de configuração (`Inform*` e `Require*`) para controlar visibilidade e obrigatoriedade dos campos
* Centralizar regras de validação por meio de lógica compartilhada (`isMetadataRequired`)
* Realizar ajustes coordenados em backend e frontend para refletir o novo modelo de dados

## 🛠️ Solução

* Criação de novos campos de execução (`executed*`) no módulo de workplan (ex: `executedRevenue` e equivalentes)
* Padronização da relação entre:

  * campos de planejamento (`delivery*`)
  * campos de monitoramento (`monitoring*`)
  * campos de execução (`executed*`)
* Correção de inconsistências nas flags de obrigatoriedade e visibilidade
* Atualização das validações no backend, considerando tipo e obrigatoriedade dos campos
* Ajustes no frontend para:

  * renderização dos novos campos
  * indicação visual de obrigatoriedade
  * exibição de erros de validação (`validationErrors`)
* Revisão de campos existentes para garantir consistência (ex: `numberOfParticipants` com flag própria de monitoramento)

## 🧪 Testes

* Testes manuais cobrindo:

  * criação e edição de planos de trabalho
  * preenchimento dos campos de execução
  * aplicação correta das regras de obrigatoriedade
* Verificação de:

  * persistência dos novos campos
  * exibição de erros no frontend
  * compatibilidade com fluxos já existentes
