### PR TITLE
9326 incorporando implementacoes 7.7.x fase de recurso

### DIFF
--- a/src/core/Entities/EvaluationMethodConfiguration.php
+++ b/src/core/Entities/EvaluationMethodConfiguration.php
@@ -142,15 +142,14 @@ class EvaluationMethodConfiguration extends \MapasCulturais\Entity {
     }
 
     function validateEvaluationDates() {
-        if($this->registrationFrom && $this->registrationTo){
-            return $this->registrationFrom <= $this->registrationTo;
-
-        }elseif($this->registrationFrom || $this->registrationTo){
-            return false;
-
-        }else{
-            return true;
+        if ($this->evaluationFrom && $this->evaluationTo) {
+            return $this->evaluationFrom <= $this->evaluationTo;
         }
+        if ($this->evaluationFrom || $this->evaluationTo) {
+            return false;
+        }
+
+        return true;
     }
 
     function setType($value) {

--- a/src/core/Entities/Opportunity.php
+++ b/src/core/Entities/Opportunity.php
@@ -1615,8 +1615,8 @@ abstract class Opportunity extends \MapasCulturais\Entity
 
         $app->applyHookBoundTo($this, "{$this->hookPrefix}.registrationMetadata");
 
-        if($also_previous_phases && $this->parent) {
-            $this->previousPhase->registerRegistrationMetadata();
+        if ($also_previous_phases && $this->parent && ($previous_phase = $this->previousPhase)) {
+            $previous_phase->registerRegistrationMetadata();
         }
 
     }

--- a/src/modules/EvaluationMethodContinuous/components/continuous-evaluation-form/script.js
+++ b/src/modules/EvaluationMethodContinuous/components/continuous-evaluation-form/script.js
@@ -62,15 +62,21 @@ app.component('continuous-evaluation-form', {
         },
 
         evaluationData() {
+            const currentEvalConfig = $MAPAS.config.continuousEvaluationForm.currentEvaluation;
             return {
-                data: $MAPAS.config.continuousEvaluationForm.currentEvaluation?.evaluationData
+                data: currentEvalConfig?.evaluationData || {}
             };
         },
 
         currentEvaluation() {
+            const currentEvalConfig = $MAPAS.config.continuousEvaluationForm.currentEvaluation;
+            if (!currentEvalConfig) {
+                return null;
+            }
+            
             const api = new API('registrationevaluation');
-            const evaluation = api.getEntityInstance($MAPAS.config.continuousEvaluationForm.currentEvaluation.id);
-            evaluation.populate($MAPAS.config.continuousEvaluationForm.currentEvaluation);
+            const evaluation = api.getEntityInstance(currentEvalConfig.id);
+            evaluation.populate(currentEvalConfig);
             return evaluation;
         },
 
@@ -119,11 +125,18 @@ app.component('continuous-evaluation-form', {
         },
 
         handleCurrentEvaluationForm() {
-            return this.currentEvaluation?.status > 0 ? this.isEditable = false : this.isEditable = this.editable;
+            if (!this.currentEvaluation) {
+                this.isEditable = this.editable;
+                return;
+            }
+            
+            return this.currentEvaluation.status > 0 ? this.isEditable = false : this.isEditable = this.editable;
         },
 
         removeEvaluationAttachment(file) {
-            this.currentEvaluation.files.evaluationAttachment = undefined;
+            if (this.currentEvaluation && this.currentEvaluation.files) {
+                this.currentEvaluation.files.evaluationAttachment = undefined;
+            }
         },
 
         statusToString(status) {

--- a/src/modules/EvaluationMethodContinuous/components/continuous-evaluation-form/template.php
+++ b/src/modules/EvaluationMethodContinuous/components/continuous-evaluation-form/template.php
@@ -44,7 +44,7 @@ $this->import('
             <textarea v-if="isEditable" v-model="formData.data.obs"></textarea>
             <textarea v-if="!isEditable" disabled>{{formData.data.obs}}</textarea>
         </div>
-        <div class="continuous-evaluation-form__content field col-12" v-if="hasChatThread && currentEvaluation.status >= 2">
+        <div class="continuous-evaluation-form__content field col-12" v-if="hasChatThread && currentEvaluation && currentEvaluation.status >= 2">
             <label class="field__label">
                 <?php i::_e('Status') ?>
             </label>
@@ -59,6 +59,7 @@ $this->import('
         </div>
 
         <entity-file
+            v-if="currentEvaluation"
             :entity="currentEvaluation"
             group-name="evaluationAttachment"
             title-modal="<?php i::_e('Anexar parecer') ?>"

--- a/src/modules/Opportunities/components/opportunity-phase-config-data-collection/script.js
+++ b/src/modules/Opportunities/components/opportunity-phase-config-data-collection/script.js
@@ -60,12 +60,12 @@ app.component('opportunity-phase-config-data-collection' , {
             let date;
 
             // se a data inicial da fase está definida, a data final não pode ser menor que a data inicial
-            if (this.phase.registraionFrom) {
-                date = this.phase.registraionFrom;
+            if (this.phase.registrationFrom) {
+                date = this.phase.registrationFrom;
 
             // senão, a data inicial não pode ser enor que a data inicial da fase anterior
             } else if(this.previousPhase) {
-                date = this.previousPhase.registrationfrom || this.previousPhase.evaluationfrom;
+                date = this.previousPhase.registrationFrom || this.previousPhase.evaluationFrom;
             }
 
             return date;

--- a/src/modules/Opportunities/components/opportunity-phase-config-evaluation/script.js
+++ b/src/modules/Opportunities/components/opportunity-phase-config-evaluation/script.js
@@ -78,7 +78,7 @@ app.component('opportunity-phase-config-evaluation' , {
 
             // senão, a data inicial não pode ser enor que a data inicial da fase anterior
             } else {
-                date = this.previousPhase.registrationfrom || this.previousPhase.evaluationfrom;
+                date = this.previousPhase.registrationFrom || this.previousPhase.evaluationFrom;
             }
 
             return date;

--- a/src/modules/Opportunities/components/opportunity-phases-config/template.php
+++ b/src/modules/Opportunities/components/opportunity-phases-config/template.php
@@ -70,7 +70,7 @@ $this->import('
             <opportunity-phase-config-results :phases="phases" :phase="item" :tab="tab"></opportunity-phase-config-results>
         </template>
     </template>
-    <template #after-li="{index, item}">
+    <template #after-li="{index, item, step}">
         <template v-if="phases[index + 1]?.isLastPhase">
             <div v-if="showButtons() && entity.registrationFrom && entity.registrationTo && !(firstPhase?.isContinuousFlow && firstPhase?.hasEndDate && !lastPhase.publishTimestamp)" class="add-phase grid-12">
                 <div class="col-12">
@@ -107,5 +107,36 @@ $this->import('
                 </div>
             </div>
         </template>
+        <div v-if="!step?.active && item.__objectType === 'evaluationmethodconfiguration' && item?.opportunity?.appealPhase" class="appeal-phase-info">
+           <div class="data-collection">
+                <div>
+                    <small><strong><?= i::__("Recurso") ?></strong></small>
+                </div>
+                <div class="data-collection-dates">
+                    <small>
+                        {{item?.opportunity?.appealPhase?.registrationFrom?.date('2-digit year')}} {{item?.opportunity?.appealPhase?.registrationFrom?.time('numeric')}}
+                    </small>
+                    <small><strong><?= i::__("à") ?></strong></small>
+                    <small>
+                        {{item?.opportunity?.appealPhase?.registrationTo?.date('2-digit year')}} {{item?.opportunity?.appealPhase?.registrationTo?.time('numeric')}}
+                    </small>
+                </div>
+           </div>
+
+           <div class="evaluation">
+                <div>
+                    <small><strong><?= i::__("Avaliação do recurso") ?></strong></small>
+                </div>
+                <div class="evaluation-dates">
+                    <small>
+                        {{item?.opportunity?.appealPhase?.evaluationMethodConfiguration?.evaluationFrom?.date('2-digit year')}} {{item?.opportunity?.appealPhase?.evaluationMethodConfiguration?.evaluationFrom?.time('numeric')}}
+                    </small>
+                    <small><strong><?= i::__("à") ?></strong></small>
+                    <small>
+                        {{item?.opportunity?.appealPhase?.evaluationMethodConfiguration?.evaluationTo?.date('2-digit year')}} {{item?.opportunity?.appealPhase?.evaluationMethodConfiguration?.evaluationTo?.time('numeric')}}
+                    </small>
+                </div>
+           </div>
+        </div>
     </template>
 </mc-stepper-vertical>

--- a/src/modules/Opportunities/components/opportunity-subscribe-results/template.php
+++ b/src/modules/Opportunities/components/opportunity-subscribe-results/template.php
@@ -75,4 +75,37 @@ $this->import('
             <opportunity-phase-status :entity="item"  :phases="phases" :tab="tab"></opportunity-phase-status>
         </template>
     </template>
+    <template #after-li="{index, item, step}">
+        <div v-if="!step?.active && item.__objectType === 'evaluationmethodconfiguration' && item?.opportunity?.appealPhase" class="appeal-phase-info">
+           <div class="data-collection">
+                <div>
+                    <small><strong><?= i::__("Recurso") ?></strong></small>
+                </div>
+                <div class="data-collection-dates">
+                    <small>
+                        {{item?.opportunity?.appealPhase?.registrationFrom?.date('2-digit year')}} {{item?.opportunity?.appealPhase?.registrationFrom?.time('numeric')}}
+                    </small>
+                    <small><strong><?= i::__("à") ?></strong></small>
+                    <small>
+                        {{item?.opportunity?.appealPhase?.registrationTo?.date('2-digit year')}} {{item?.opportunity?.appealPhase?.registrationTo?.time('numeric')}}
+                    </small>
+                </div>
+           </div>
+
+           <div class="evaluation">
+                <div>
+                    <small><strong><?= i::__("Avaliação do recurso") ?></strong></small>
+                </div>
+                <div class="evaluation-dates">
+                    <small>
+                        {{item?.opportunity?.appealPhase?.evaluationMethodConfiguration?.evaluationFrom?.date('2-digit year')}} {{item?.opportunity?.appealPhase?.evaluationMethodConfiguration?.evaluationFrom?.time('numeric')}}
+                    </small>
+                    <small><strong><?= i::__("à") ?></strong></small>
+                    <small>
+                        {{item?.opportunity?.appealPhase?.evaluationMethodConfiguration?.evaluationTo?.date('2-digit year')}} {{item?.opportunity?.appealPhase?.evaluationMethodConfiguration?.evaluationTo?.time('numeric')}}
+                    </small>
+                </div>
+           </div>
+        </div>
+    </template>
 </mc-stepper-vertical>

--- a/src/modules/Opportunities/components/registration-distribution-rule/init.php
+++ b/src/modules/Opportunities/components/registration-distribution-rule/init.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ *
+ * @var MapasCulturais\App $app
+ * @var MapasCulturais\Themes\BaseV2\Theme $this
+ */
+
+use MapasCulturais\Entities\Agent;
+use MapasCulturais\Entities\Opportunity;
+
+$entity = $this->controller->requestedEntity ?? null;
+if (!$entity) {
+    return;
+}
+
+$opportunity = $entity instanceof Opportunity ? $entity : null;
+
+if (!$opportunity && method_exists($entity, 'getOpportunity')) {
+    $opportunity = $entity->getOpportunity();
+}
+
+if (!$opportunity || !$opportunity->firstPhase) {
+    return;
+}
+
+$agent_description = Agent::getPropertiesMetadata();
+$field_types = ['select', 'checkboxes', 'checkbox'];
+
+$parse_agent_field = function ($field) use ($agent_description, $field_types) {
+    $config = is_array($field->config ?? null) ? $field->config : [];
+    $agent_field_name = $config['entityField'] ?? null;
+
+    if (!$agent_field_name || !in_array($agent_field_name, array_keys($agent_description))) {
+        return null;
+    }
+
+    $agent_field = $agent_description[$agent_field_name];
+
+    return in_array($agent_field['type'], $field_types) ? $field : null;
+};
+
+$phases = (array) $opportunity->allPhases;
+$appeal_phases = [];
+
+foreach ($phases as $phase) {
+    if ($appeal_phase = $phase->appealPhase) {
+        $appeal_phases[] = $appeal_phase;
+    }
+}
+
+$_fields = [];
+
+foreach ([...$phases, ...$appeal_phases] as $phase) {
+    $is_appeal_phase = (bool) ($phase->isAppealPhase ?? false);
+
+    foreach ($phase->registrationFieldConfigurations ?? [] as $field) {
+        $field_to_add = null;
+
+        if (in_array($field->fieldType ?? '', ['agent-owner-field', 'agent-collective-field'])) {
+            $parsed = $parse_agent_field($field);
+
+            if ($parsed) {
+                $field_to_add = $parsed;
+            }
+        } elseif (in_array($field->fieldType ?? '', ['select', 'checkboxes', 'checkbox'])) {
+            $field_to_add = $field;
+        }
+
+        if (!$field_to_add) {
+            continue;
+        }
+
+        $_fields[] = [
+            'id' => $field_to_add->id,
+            'fieldName' => $field_to_add->fieldName,
+            'title' => $field_to_add->title ?: $field_to_add->fieldName,
+            'fieldType' => $field_to_add->fieldType ?: 'select',
+            'fieldOptions' => $field_to_add->fieldOptions ?? [],
+            'appealPhase' => $is_appeal_phase,
+        ];
+    }
+}
+
+$this->jsObject['config']['registrationFilterFields'] = $_fields;

--- a/src/modules/Opportunities/components/registration-distribution-rule/script.js
+++ b/src/modules/Opportunities/components/registration-distribution-rule/script.js
@@ -1,0 +1,923 @@
+app.component('registration-distribution-rule', {
+    template: $TEMPLATES['registration-distribution-rule'],
+    emits: ['update:modelValue', 'update:parentFilters'],
+
+    props: {
+        opportunity: {
+            type: Entity,
+            required: true
+        },
+        modelValue: {
+            type: Object,
+            default: () => ({
+                categories: [],
+                proponentTypes: [],
+                ranges: [],
+                distribution: '',
+                sentTimestamp: { from: '', to: '' },
+                fields: {}
+            })
+        },
+        parentFilters: {
+            type: Object,
+            default: null
+        },
+        disableFilters: {
+            type: [Array, Object],
+            default: () => []
+        },
+        enableFilterByNumber: {
+            type: Boolean,
+            default: false
+        },
+        enableFilterBySentTimestamp: {
+            type: Boolean,
+            default: false
+        },
+        titleModal: {
+            type: String,
+            default: ''
+        }
+    },
+
+    setup() {
+        const text = Utils.getTexts('registration-distribution-rule');
+        return { text };
+    },
+
+    data() {
+        return {
+            selectedField: '',
+            selectedConfigs: [],
+            selectedDistribution: '',
+            localModel: this.normalizeModel(this.modelValue)
+        };
+    },
+
+    computed: {
+        phase() {
+            const opp = this.opportunity;
+
+            if (!opp) {
+                return null;
+            }
+
+            const first = opp.firstPhase || opp;
+            const phases = first.phases || (Array.isArray(first) ? first : [first]);
+
+            return phases[0] || first;
+        },
+
+        registrationCategories() {
+            return this.phase?.registrationCategories ?? [];
+        },
+
+        registrationProponentTypes() {
+            return this.phase?.registrationProponentTypes ?? [];
+        },
+
+        registrationRanges() {
+            const ranges = this.phase?.registrationRanges ?? [];
+            return Array.isArray(ranges) ? ranges.map(range => (typeof range === 'object' && range?.label != null ? range.label : range)) : [];
+        },
+
+        selectionFields() {
+            const opp = this.opportunity;
+            const allowed = ['select', 'checkboxes', 'checkbox'];
+            const byId = {};
+
+            const isAppealPhase = opp?.isAppealPhase === true;
+
+            const fromConfigs = (configs) => {
+                (configs || []).forEach(field => {
+                    if (allowed.includes(field.fieldType) && field.fieldName) {
+                        const id = String(field.id ?? field.fieldName);
+                        byId[id] = {
+                            fieldName: field.fieldName,
+                            title: field.title || field.fieldName,
+                            fieldType: field.fieldType || 'select',
+                            fieldOptions: field.fieldOptions || []
+                        };
+                    }
+                });
+            };
+
+            const configs = opp?.registrationFieldConfigurations;
+
+            if (configs && configs.length) {
+                fromConfigs(configs);
+            }
+
+            if (typeof $MAPAS != 'undefined' && $MAPAS.config?.registrationFilterFields) {
+                const filterFields = $MAPAS.config.registrationFilterFields;
+                filterFields.forEach(field => {
+                    if (!field) {
+                        return;
+                    }
+
+                    if (!isAppealPhase && field.appealPhase) {
+                        return;
+                    }
+
+                    const id = String(field.fieldName || field.id);
+
+                    if (byId[id]) {
+                        return;
+                    }
+
+                    byId[id] = {
+                        fieldName: field.fieldName || id,
+                        title: field.title || field.fieldName || id,
+                        fieldType: field.fieldType || 'select',
+                        fieldOptions: field.fieldOptions || []
+                    };
+                });
+            }
+
+            return byId;
+        },
+
+        selectedFieldType() {
+            if (!this.selectedField) {
+                return '';
+            }
+
+            return this.selectedField.startsWith('field:') ? 'field' : this.selectedField;
+        },
+
+        selectedFieldId() {
+            if (this.selectedFieldType !== 'field') {
+                return null;
+            }
+
+            return this.selectedField.replace(/^field:/, '');
+        },
+
+        filteredCategories() {
+            let list = this.registrationCategories;
+            
+            if (this.hasCommissionFilters && this.parentFilters && Array.isArray(this.parentFilters.categories) && this.parentFilters.categories.length > 0) {
+                list = list.filter(cat => this.parentFilters.categories.includes(cat));
+            }
+ 
+            const disabled = this.disabledValues.categories || [];
+
+            return list.filter(cat => !disabled.includes(cat));
+        },
+
+        filteredProponentTypes() {
+            let list = this.registrationProponentTypes;
+            
+            if (this.hasCommissionFilters && this.parentFilters && Array.isArray(this.parentFilters.proponentTypes) && this.parentFilters.proponentTypes.length > 0) {
+                list = list.filter(type => this.parentFilters.proponentTypes.includes(type));
+            }
+
+            const disabled = this.disabledValues.proponentTypes || [];
+  
+            return list.filter(type => !disabled.includes(type));
+        },
+
+        filteredRanges() {
+            let list = this.registrationRanges;
+            
+            if (this.hasCommissionFilters && this.parentFilters && Array.isArray(this.parentFilters.ranges) && this.parentFilters.ranges.length > 0) {
+                list = list.filter(range => this.parentFilters.ranges.includes(range));
+            }
+
+            const disabled = this.disabledValues.ranges || [];
+
+            return list.filter(range => !disabled.includes(range));
+        },
+
+        canConfirm() {
+            if (this.selectedField === 'sentTimestamp') {
+                const from = this.selectedConfigs?.from;
+                const to = this.selectedConfigs?.to;
+
+                if (!from && !to) {
+                    return false;
+                }
+
+                if (from && to && new Date(to) < new Date(from)) {
+                    return false;
+                }
+            }
+
+            return true;
+        },
+
+        sentTimestampErrors() {
+            if (this.selectedField !== 'sentTimestamp') {
+                return { from: '', to: '' };
+            }
+
+            const from = this.selectedConfigs?.from;
+            const to = this.selectedConfigs?.to;
+
+            if (from && to && new Date(from) > new Date(to)) {
+                return { from: this.text('A data inicial não pode ser maior que a data final'), to: '' };
+            }
+
+            return { from: '', to: '' };
+        },
+
+        tagsList() {
+            return this.buildTagsList();
+        },
+
+        tagsLabels() {
+            return this.buildTagsLabels();
+        },
+
+        disabledTypes() {
+            return Array.isArray(this.disableFilters) ? this.disableFilters : [];
+        },
+
+        disabledValues() {
+            return Array.isArray(this.disableFilters) ? {} : (this.disableFilters || {});
+        },
+
+        /** Verifica se a comissão tem pelo menos um filtro configurado */
+        hasCommissionFilters() {
+            if (!this.parentFilters || typeof this.parentFilters !== 'object') {
+                return false;
+            }
+
+            if (Array.isArray(this.parentFilters.categories) && this.parentFilters.categories.length > 0) {
+                return true;
+            }
+
+            if (Array.isArray(this.parentFilters.proponentTypes) && this.parentFilters.proponentTypes.length > 0) {
+                return true;
+            }
+
+            if (Array.isArray(this.parentFilters.ranges) && this.parentFilters.ranges.length > 0) {
+                return true;
+            }
+
+            if (this.parentFilters.fields && typeof this.parentFilters.fields === 'object' && Object.keys(this.parentFilters.fields).length > 0) {
+                return true;
+            }
+
+            if (this.parentFilters.distribution && typeof this.parentFilters.distribution === 'string' && this.parentFilters.distribution.trim()) {
+                return true;
+            }
+
+            if (this.parentFilters.sentTimestamp && typeof this.parentFilters.sentTimestamp === 'object' && (this.parentFilters.sentTimestamp.from || this.parentFilters.sentTimestamp.to)) {
+                return true;
+            }
+
+            return false;
+        },
+
+        availableFields() {
+            if (!this.isFilterAvailable('fields')) {
+                return {};
+            }
+
+            const available = {};
+            Object.entries(this.selectionFields).forEach(([fieldId, field]) => {
+                if (this.isFieldAllowedByParent(fieldId)) {
+                    available[fieldId] = field;
+                }
+            });
+
+            return available;
+        }
+    },
+
+    watch: {
+        modelValue: {
+            handler(val) {
+                this.localModel = this.normalizeModel(val);
+            },
+            deep: true
+        },
+        parentFilters: {
+            handler(newVal) {
+                this.applyParentRestrictions();
+                this.$emit('update:parentFilters', newVal ?? null);
+            },
+            deep: true
+        },
+        disableFilters: {
+            handler() {
+                this.applyParentRestrictions();
+            },
+            deep: true
+        }
+    },
+
+    mounted() {
+        this.localModel = this.normalizeModel(this.modelValue);
+        this.applyParentRestrictions();
+        
+        if (this.parentFilters != null) {
+            this.$emit('update:parentFilters', this.parentFilters);
+        }
+    },
+
+    methods: {
+        normalizeModel(val) {
+            const model = val || {};
+
+            return {
+                categories: Array.isArray(model.categories) ? [...model.categories] : [],
+                proponentTypes: Array.isArray(model.proponentTypes) ? [...model.proponentTypes] : [],
+                ranges: Array.isArray(model.ranges) ? [...model.ranges] : [],
+                distribution: typeof model.distribution == 'string' ? model.distribution : '',
+                sentTimestamp: {
+                    from: model.sentTimestamp?.from ?? '',
+                    to: model.sentTimestamp?.to ?? ''
+                },
+                fields: model.fields && typeof model.fields == 'object' ? { ...model.fields } : {}
+            };
+        },
+
+        applyParentRestrictions() {
+            if (!this.localModel) {
+                return;
+            }
+            
+            const next = { ...this.normalizeModel(this.localModel) };
+            let changed = false;
+            const disabled = this.disabledValues;
+
+            if (this.parentFilters && Array.isArray(this.parentFilters.categories) && this.parentFilters.categories.length > 0) {
+                const allowed = new Set(this.parentFilters.categories);
+                const disabledCategories = disabled.categories || [];
+                const prev = next.categories.length;
+                next.categories = next.categories.filter(c => {
+                    return allowed.has(c) && disabledCategories.indexOf(c) === -1;
+                });
+                
+                if (next.categories.length != prev) {
+                    changed = true;
+                }
+            } else if (Array.isArray(disabled.categories) && disabled.categories.length > 0) {
+                const prev = next.categories.length;
+                next.categories = next.categories.filter(c => disabled.categories.indexOf(c) === -1);
+                
+                if (next.categories.length != prev) {
+                    changed = true;
+                }
+            }
+
+            if (this.parentFilters && Array.isArray(this.parentFilters.proponentTypes) && this.parentFilters.proponentTypes.length > 0) {
+                const allowed = new Set(this.parentFilters.proponentTypes);
+                const disabledProponentTypes = disabled.proponentTypes || [];
+                const prev = next.proponentTypes.length;
+                next.proponentTypes = next.proponentTypes.filter(p => {
+                    return allowed.has(p) && disabledProponentTypes.indexOf(p) === -1;
+                });
+                
+                if (next.proponentTypes.length != prev) {
+                    changed = true;
+                }
+            } else if (Array.isArray(disabled.proponentTypes) && disabled.proponentTypes.length > 0) {
+                const prev = next.proponentTypes.length;
+                next.proponentTypes = next.proponentTypes.filter(p => disabled.proponentTypes.indexOf(p) === -1);
+                
+                if (next.proponentTypes.length != prev) {
+                    changed = true;
+                }
+            }
+
+            if (this.parentFilters && Array.isArray(this.parentFilters.ranges) && this.parentFilters.ranges.length > 0) {
+                const allowed = new Set(this.parentFilters.ranges);
+                const disabledRanges = disabled.ranges || [];
+                const prev = next.ranges.length;
+                next.ranges = next.ranges.filter(r => {
+                    return allowed.has(r) && disabledRanges.indexOf(r) === -1;
+                });
+                
+                if (next.ranges.length != prev) {
+                    changed = true;
+                }
+            } else if (Array.isArray(disabled.ranges) && disabled.ranges.length > 0) {
+                const prev = next.ranges.length;
+                next.ranges = next.ranges.filter(r => disabled.ranges.indexOf(r) === -1);
+                
+                if (next.ranges.length != prev) {
+                    changed = true;
+                }
+            }
+
+            if (this.parentFilters && this.parentFilters.fields && typeof this.parentFilters.fields === 'object') {
+                const nextFields = {};
+                const disabledFields = disabled.fields || {};
+
+                for (const [fieldId, allowedValues] of Object.entries(this.parentFilters.fields)) {
+                    if (!Array.isArray(allowedValues) || allowedValues.length === 0) {
+                        continue;
+                    }
+
+                    const allowedSet = new Set(allowedValues);
+                    const disabledForField = disabledFields[fieldId] || [];
+                    const disabledSet = new Set(disabledForField);
+                    const current = next.fields[fieldId];
+                    
+                    if (Array.isArray(current)) {
+                        const filtered = current.filter(v => {
+                            return allowedSet.has(v) && !disabledSet.has(v);
+                        });
+                        
+                        if (filtered.length > 0) {
+                            nextFields[fieldId] = filtered;
+                        }
+                    }
+                }
+
+                const prevKeys = Object.keys(next.fields).sort().join('');
+                const nextKeys = Object.keys(nextFields).sort().join('');
+
+                if (prevKeys != nextKeys) {
+                    changed = true;
+                } else {
+                    for (const k of Object.keys(next.fields)) {
+                        const a = (next.fields[k] || []).slice().sort().join();
+                        const b = (nextFields[k] || []).slice().sort().join();
+                        
+                        if (a != b) {
+                            changed = true;
+                            break;
+                        }
+                    }
+                }
+                next.fields = nextFields;
+            } else if (disabled.fields && typeof disabled.fields === 'object') {
+                const nextFields = {};
+                const disabledFields = disabled.fields;
+
+                Object.entries(next.fields || {}).forEach(([fieldId, values]) => {
+                    if (!Array.isArray(values)) {
+                        return;
+                    }
+
+                    const disabledForField = disabledFields[fieldId] || [];
+                    const filtered = values.filter(v => disabledForField.indexOf(v) === -1);
+                    
+                    if (filtered.length > 0) {
+                        nextFields[fieldId] = filtered;
+                    }
+                });
+
+                const prevKeys = Object.keys(next.fields).sort().join('');
+                const nextKeys = Object.keys(nextFields).sort().join('');
+
+                if (prevKeys != nextKeys) {
+                    changed = true;
+                } else {
+                    for (const k of Object.keys(next.fields)) {
+                        const a = (next.fields[k] || []).slice().sort().join();
+                        const b = (nextFields[k] || []).slice().sort().join();
+                        
+                        if (a != b) {
+                            changed = true;
+                            break;
+                        }
+                    }
+                }
+                next.fields = nextFields;
+            }
+
+            if (changed) {
+                this.localModel = next;
+                this.$emit('update:modelValue', next);
+            }
+        },
+
+        isFilterAvailable(type) {
+            if (this.disabledTypes.includes(type)) {
+                return false;
+            }
+
+            if (type === 'categories') {
+                if (this.registrationCategories.length === 0) {
+                    return false;
+                }
+
+                if (this.hasCommissionFilters && this.parentFilters && Array.isArray(this.parentFilters.categories) && this.parentFilters.categories.length > 0) {
+                    return this.parentFilters.categories.length > 1;
+                }
+
+                return this.filteredCategories.length > 0;
+            }
+
+            if (type === 'proponentTypes') {
+                if (this.registrationProponentTypes.length === 0) {
+                    return false;
+                }
+                
+                if (this.hasCommissionFilters && this.parentFilters && Array.isArray(this.parentFilters.proponentTypes) && this.parentFilters.proponentTypes.length > 0) {
+                    return this.parentFilters.proponentTypes.length > 1;
+                }
+
+                return this.filteredProponentTypes.length > 0;
+            }
+
+            if (type === 'ranges') {
+                if (this.registrationRanges.length === 0) {
+                    return false;
+                }
+                
+                if (this.hasCommissionFilters && this.parentFilters && Array.isArray(this.parentFilters.ranges) && this.parentFilters.ranges.length > 0) {
+                    return this.parentFilters.ranges.length > 1;
+                }
+
+                return this.filteredRanges.length > 0;
+            }
+
+            if (type === 'distribution') {
+                return this.enableFilterByNumber;
+            }
+
+            if (type === 'sentTimestamp') {
+                return this.enableFilterBySentTimestamp;
+            }
+
+            if (type === 'fields') {
+                if (Object.keys(this.selectionFields).length === 0) {
+                    return false;
+                }
+
+                if (this.hasCommissionFilters && this.parentFilters && this.parentFilters.fields && typeof this.parentFilters.fields === 'object') {
+                    const fieldsKeys = Object.keys(this.parentFilters.fields);
+                    if (fieldsKeys.length > 0) {
+                        const hasFields = fieldsKeys.some(id => {
+                            const arr = this.parentFilters.fields[id];
+                            return Array.isArray(arr) && arr.length > 0;
+                        });
+                        
+                        if (hasFields) {
+                            return true;
+                        }
+                    }
+                }
+                
+                return Object.keys(this.selectionFields).some(fieldId => {
+                    return this.getFieldOptions(fieldId).length > 0;
+                });
+            }
+
+            return false;
+        },
+
+        isFilterDisabled(type) {
+            if (this.disabledTypes.includes(type)) {
+                return true;
+            }
+
+            return false;
+        },
+
+        isFieldAllowedByParent(fieldId) {
+            if (this.hasCommissionFilters && this.parentFilters?.fields && typeof this.parentFilters.fields === 'object') {
+                const allowed = this.parentFilters.fields[fieldId];
+
+                if (Array.isArray(allowed) && allowed.length > 0) {
+                    return true;
+                }
+            }
+
+            return this.getFieldOptions(fieldId).length > 0;
+        },
+
+        getFieldOptions(fieldId) {
+            const field = this.selectionFields[fieldId];
+            if (!field) {
+                return [];
+            }
+
+            let options = [];
+
+            if (field.fieldType === 'checkbox') {
+                const parentOptsRaw = this.parentFilters?.fields?.[fieldId];
+                
+                if (Array.isArray(parentOptsRaw) && parentOptsRaw.length > 0) {
+                    let hasTrue = false;
+                    let hasFalse = false;
+                    
+                    parentOptsRaw.forEach((val) => {
+                        if (val === true || val === 'true' || val === 1 || val === '1' || val === 'on') {
+                            hasTrue = true;
+                        } else if (val === false || val === 'false' || val === 0 || val === '0' || val === '' || val == null) {
+                            hasFalse = true;
+                        } else {
+                            hasTrue = true;
+                        }
+                    });
+
+                    options = [];
+                    if (hasTrue) {
+                        options.push(true);
+                    }
+                    if (hasFalse) {
+                        options.push(false);
+                    }
+                    
+                    return options;
+                } else {
+                    options = [true, false];
+                }
+            } else {
+                options = field.fieldOptions || [];
+
+                if (!options.length) {
+                    return [];
+                }
+
+                const parentOpts = this.parentFilters?.fields?.[fieldId];
+                if (Array.isArray(parentOpts) && parentOpts.length > 0) {
+                    options = options.filter(option => parentOpts.includes(option));
+                    return options;
+                }
+            }
+
+            const disabledValuesForField = this.disabledValues.fields?.[fieldId] || [];
+            if (Array.isArray(disabledValuesForField) && disabledValuesForField.length > 0) {
+                options = options.filter(option => disabledValuesForField.indexOf(option) === -1);
+            }
+
+            return options;
+        },
+
+        getFieldOptionLabel(fieldId, option) {
+            const field = this.selectionFields[fieldId];
+
+            if (field?.fieldType == 'checkbox') {
+                if (option == true) {
+                    return this.text('Marcado');
+                }
+
+                if (option == false) {
+                    return this.text('Desmarcado');
+                }
+            }
+
+            return String(option);
+        },
+
+        handleSelection() {
+            const field = this.selectedField;
+            const model = this.localModel;
+
+            if (field == 'sentTimestamp') {
+                this.selectedConfigs = {
+                    from: model.sentTimestamp?.from ?? '',
+                    to: model.sentTimestamp?.to ?? ''
+                };
+                return;
+            }
+
+            if (field == 'distribution') {
+                this.selectedDistribution = model.distribution ?? '';
+                return;
+            }
+
+            if (field.startsWith('field:')) {
+                const fieldId = field.replace(/^field:/, '');
+                this.selectedConfigs = Array.isArray(model.fields?.[fieldId]) ? [...model.fields[fieldId]] : [];
+                return;
+            }
+
+            this.selectedConfigs = Array.isArray(model[field]) ? [...model[field]] : [];
+        },
+
+        addConfig(modal) {
+            const field = this.selectedField;
+            const next = { ...this.normalizeModel(this.localModel) };
+
+            if (field == 'sentTimestamp') {
+                const from = this.selectedConfigs?.from;
+                const to = this.selectedConfigs?.to;
+
+                if (!from && !to) {
+                    modal.close();
+                    return;
+                }
+
+                if (from && to && new Date(to) < new Date(from)) {
+                    modal.close();
+                    return;
+                }
+
+                next.sentTimestamp = {
+                    from: from ? this.formatSentTimestamp(from) : '',
+                    to: to ? this.formatSentTimestamp(to) : ''
+                };
+            }
+
+            if (field == 'distribution') {
+                next.distribution = this.selectedDistribution?.trim() ?? '';
+            }
+
+            if (field.startsWith('field:')) {
+                const fieldId = field.replace(/^field:/, '');
+                if (!next.fields) {
+                    next.fields = {};
+                }
+                next.fields[fieldId] = Array.isArray(this.selectedConfigs) ? [...this.selectedConfigs] : [];
+            }
+
+            if (['categories', 'proponentTypes', 'ranges'].includes(field)) {
+                next[field] = Array.isArray(this.selectedConfigs) ? [...this.selectedConfigs] : [];
+            }
+
+            this.localModel = next;
+            this.$emit('update:modelValue', next);
+            this.selectedField = '';
+            this.selectedConfigs = [];
+            this.selectedDistribution = '';
+            modal.close();
+        },
+
+        formatSentTimestamp(dateString) {
+            if (!dateString) {
+                return '';
+            }
+
+            try {
+                const date = new Date(dateString);
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                const day = String(date.getDate()).padStart(2, '0');
+                const hours = String(date.getHours()).padStart(2, '0');
+                const minutes = String(date.getMinutes()).padStart(2, '0');
+                const seconds = String(date.getSeconds()).padStart(2, '0');
+
+                return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+            } catch (error) {
+                return dateString;
+            }
+        },
+
+        formatDateDisplay(dateString) {
+            if (!dateString) {
+                return '';
+            }
+
+            try {
+                const date = new Date(dateString);
+                const day = String(date.getDate()).padStart(2, '0');
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                const year = date.getFullYear();
+
+                return `${day}/${month}/${year}`;
+            } catch (error) {
+                return dateString;
+            }
+        },
+
+        buildTagsList() {
+            const list = [];
+            const model = this.localModel;
+            const formatDate = this.formatDateDisplay;
+
+            if (model.sentTimestamp && (model.sentTimestamp.from || model.sentTimestamp.to)) {
+                if (model.sentTimestamp.from) {
+                    list.push(`${this.text('Data de envio')} - ${this.text('de')} ${formatDate(model.sentTimestamp.from)}`);
+                }
+
+                if (model.sentTimestamp.to) {
+                    list.push(`${this.text('Data de envio')} - ${this.text('até')} ${formatDate(model.sentTimestamp.to)}`);
+                }
+            }
+
+            const propToLabelKey = { categories: 'Categorias', proponentTypes: 'Tipos de proponente', ranges: 'Faixas/Linhas' };
+            ['categories', 'proponentTypes', 'ranges'].forEach(prop => {
+                const label = this.text(propToLabelKey[prop]);
+                (model[prop] || []).forEach(value => list.push(`${label}: ${value}`));
+            });
+
+            if (model.distribution) {
+                list.push(`${this.text('Distribuição')}: ${model.distribution}`);
+            }
+
+            if (model.fields && typeof model.fields === 'object') {
+                Object.entries(model.fields).forEach(([fieldId, values]) => {
+                    const field = this.selectionFields[fieldId];
+                    const title = field?.title || fieldId;
+                    (values || []).forEach(value => {
+                        const displayValue = this.getFieldOptionLabel(fieldId, value);
+                        list.push(`${title}: ${displayValue}`);
+                    });
+                });
+            }
+
+            return list.sort();
+        },
+
+        buildTagsLabels() {
+            const labels = {};
+            this.buildTagsList().forEach(tag => { labels[tag] = tag; });
+
+            return labels;
+        },
+
+        removeTag(tag) {
+            const model = { ...this.normalizeModel(this.localModel) };
+
+            if (tag.includes(' - ')) {
+                const parts = tag.split(' - ');
+                const keyPart = parts[0].trim();
+                const datePart = parts[1]?.trim() || '';
+
+                if (keyPart === this.text('Data de envio') || keyPart.indexOf('envio') !== -1) {
+                    const toLabel = (this.text('até') || 'até').toLowerCase();
+                    const dateMatch = datePart.match(new RegExp(`^(de|${toLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})\\s+(.+)$`, 'i'));
+                    
+                    if (dateMatch) {
+                        const type = dateMatch[1].toLowerCase();
+                        
+                        if (type === 'de' || type === (this.text('de') || 'de').toLowerCase()) {
+                            model.sentTimestamp.from = '';
+                        } else {
+                            model.sentTimestamp.to = '';
+                        }
+
+                        if (!model.sentTimestamp.from && !model.sentTimestamp.to) {
+                            model.sentTimestamp = { from: '', to: '' };
+                        }
+
+                        this.localModel = this.normalizeModel(model);
+                        this.$emit('update:modelValue', this.localModel);
+                        return;
+                    }
+                }
+            }
+
+            const colonIndex = tag.indexOf(': ');
+            
+            if (colonIndex === -1) {
+                return;
+            }
+
+            const displayKey = tag.substring(0, colonIndex);
+            const value = tag.substring(colonIndex + 2);
+
+            if (displayKey == this.text('Distribuição')) {
+                model.distribution = '';
+            }
+
+            const isArrayKey = ['categories', 'proponentTypes', 'ranges'].includes(this.labelToKey(displayKey));
+            if (isArrayKey) {
+                const key = this.labelToKey(displayKey);
+                
+                if (Array.isArray(model[key])) {
+                    model[key] = model[key].filter(item => item != value);
+                }
+            }
+
+            if (model.fields && typeof model.fields == 'object') {
+                const fieldId = this.labelToFieldId(displayKey);
+                
+                if (fieldId && Array.isArray(model.fields[fieldId])) {
+                    const field = this.selectionFields[fieldId];
+                    
+                    if (field?.fieldType === 'checkbox') {
+                        const checkedLabel = this.text('Marcado');
+                        const uncheckedLabel = this.text('Desmarcado');
+                        
+                        let valueToRemove = null;
+                        if (value === checkedLabel) {
+                            valueToRemove = true;
+                        } else if (value === uncheckedLabel) {
+                            valueToRemove = false;
+                        }
+                        
+                        if (valueToRemove !== null) {
+                            model.fields[fieldId] = model.fields[fieldId].filter(item => item !== valueToRemove);
+                        }
+                    } else {
+                        model.fields[fieldId] = model.fields[fieldId].filter(item => item != value);
+                    }
+                    
+                    if (model.fields[fieldId].length == 0) {
+                        delete model.fields[fieldId];
+                    }
+                }
+            }
+
+            this.localModel = this.normalizeModel(model);
+            this.$emit('update:modelValue', this.localModel);
+        },
+
+        labelToKey(displayKey) {
+            const map = { [this.text('Categorias')]: 'categories', [this.text('Tipos de proponente')]: 'proponentTypes', [this.text('Faixas/Linhas')]: 'ranges' };
+            return map[displayKey] || null;
+        },
+
+        labelToFieldId(displayKey) {
+            const entries = Object.entries(this.selectionFields || {});
+            
+            for (const [id, field] of entries) {
+                if ((field.title || id) == displayKey) {
+                    return id;
+                }
+            }
+
+            return null;
+        }
+    }
+});

--- a/src/modules/Opportunities/components/registration-evaluation-tab/init.php
+++ b/src/modules/Opportunities/components/registration-evaluation-tab/init.php
@@ -3,43 +3,75 @@
 use MapasCulturais\i;
 
 $requestedEntity = $this->controller->requestedEntity;
-$phases = $requestedEntity->opportunity->phases;
+$firstPhaseOpp = $requestedEntity->firstPhase->opportunity;
+$phases = $firstPhaseOpp->phases;
 $phase_valuers = [];
 $phase_evaluations = [];
 $registration_number = $requestedEntity->number;
 
+$addPhaseValuers = function ($phaseOrEmc, $opportunity, &$phase_valuers, &$phase_evaluations) use ($app, $registration_number) {
+    $relatedAgents = $phaseOrEmc->relatedAgents ?? [];
+    $oppId = (int) ($opportunity->id ?? $opportunity);
+    $phase_valuers[$oppId] = [];
+    $phase_evaluations[$oppId] = [];
+
+    $opportunityEntity = ($opportunity instanceof \MapasCulturais\Entities\Opportunity)
+        ? $opportunity
+        : $app->repo('Opportunity')->find($oppId);
+    if (!$opportunityEntity) {
+        return;
+    }
+
+    $registration = $app->repo('Registration')->findOneBy([
+        'opportunity' => $opportunityEntity,
+        'number' => $registration_number
+    ]);
+
+    foreach ($relatedAgents as $group => $agents) {
+        foreach ($agents as $agent) {
+            $statuses = [
+                i::__('Avaliação iniciada'),
+                i::__('Avaliação concluída'),
+                i::__('Avaliação enviada'),
+            ];
+
+            $userId = (int) ($agent->user->id ?? $agent->user ?? 0);
+            $user = ($agent->user instanceof \MapasCulturais\Entities\User)
+                ? $agent->user
+                : $app->repo('User')->find($userId);
+            if (!$user) {
+                continue;
+            }
+            if ($registration && ($evaluation = $registration->getUserEvaluation($user))) {
+                $status = $statuses[$evaluation->status];
+                $result_string = $evaluation->resultString;
+            } else {
+                $status = i::__('Avaliação pendente');
+                $result_string = '';
+            }
+
+            $agentData = method_exists($agent, 'simplify') ? $agent->simplify() : (object) [
+                'id' => $agent->id ?? $user->profile->id ?? null,
+                'name' => $agent->name ?? $user->profile->name ?? '',
+            ];
+            $phase_valuers[$oppId][$user->id] = $agentData;
+            $phase_evaluations[$oppId][$user->id] = [
+                'status' => $status,
+                'resultString' => $result_string,
+            ];
+        }
+    }
+};
+
 foreach ($phases as $phase) {
     if ($phase->{'@entityType'} == 'evaluationmethodconfiguration') {
-        $phase_valuers[$phase->opportunity->id] = [];
-        $phase_evaluations[$phase->opportunity->id] = [];
+        $opp = $phase->opportunity;
+        $addPhaseValuers($phase, $opp, $phase_valuers, $phase_evaluations);
 
-        $registration = $app->repo('Registration')->findOneBy([
-            'opportunity' => $phase->opportunity,
-            'number' => $registration_number
-        ]);
-
-        foreach ($phase->relatedAgents as $group => $agents) {
-            foreach ($agents as $agent) {
-                $statuses = [
-                    i::__('Avaliação iniciada'),
-                    i::__('Avaliação concluída'),
-                    i::__('Avaliação enviada'),
-                ];
-
-                if ($registration && ($evaluation = $registration->getUserEvaluation($agent->user))) {
-                    $status = $statuses[$evaluation->status];
-                    $result_string = $evaluation->resultString;
-                } else {
-                    $status = i::__('Avaliação pendente');
-                    $result_string = '';
-                }
-
-                $phase_valuers[$phase->opportunity->id][$agent->user->id] = $agent->simplify();
-                $phase_evaluations[$phase->opportunity->id][$agent->user->id] = [
-                    'status' => $status,
-                    'resultString' => $result_string,
-                ];
-            }
+        // Fase de recurso: não está na cadeia nextPhase; é acessada por opportunity->appealPhase
+        $appealOpp = $opp->appealPhase ?? null;
+        if ($appealOpp && ($appealEmc = $appealOpp->evaluationMethodConfiguration ?? null)) {
+            $addPhaseValuers($appealEmc, $appealOpp, $phase_valuers, $phase_evaluations);
         }
     }
 }

--- a/src/modules/Opportunities/components/registration-evaluation-tab/script.js
+++ b/src/modules/Opportunities/components/registration-evaluation-tab/script.js
@@ -27,6 +27,9 @@ app.component('registration-evaluation-tab', {
             let result = [];
             const phaseId = this.phaseId;
             const phaseValuers = this.valuers[phaseId];
+            if (!phaseValuers || typeof phaseValuers !== 'object') {
+                return result;
+            }
             for (const userId in phaseValuers) {
                 const valuer = phaseValuers[userId];
 
@@ -48,8 +51,8 @@ app.component('registration-evaluation-tab', {
         },
 
         evaluations() {
-            const evaluations = $MAPAS.config.registrationEvaluationTab.evaluations;
-            return evaluations[this.phaseId];
+            const evaluations = $MAPAS.config.registrationEvaluationTab?.evaluations || {};
+            return evaluations[this.phaseId] || {};
         }
     },
 

--- a/src/modules/Opportunities/components/registration-status/script.js
+++ b/src/modules/Opportunities/components/registration-status/script.js
@@ -60,7 +60,8 @@ app.component('registration-status', {
                 return false;
             }
 
-            return this.registration.status > 1 && this.registration.status < 10;
+
+            return this.registration.status > 1 && this.registration.status <= 10;
         },
 
         opportunity() {

--- a/src/modules/Opportunities/views/registration/single.php
+++ b/src/modules/Opportunities/views/registration/single.php
@@ -303,20 +303,33 @@ $today = new DateTime();
         <mc-tab v-if="entity.opportunity.currentUserPermissions['@control']" label="<?= i::_e('Avaliadores') ?>" slug="valuers">
             <div class="registration__content">
                 <mc-tabs>
-                <?php $phase = $entity; 
-                    while($phase):
-                        if (!($emc = $phase->opportunity->evaluationMethodConfiguration)) {
-                            $phase = $phase->nextPhase; 
-                            continue;
-                        }
+                <?php
+                $phase = $entity;
+                while ($phase):
+                    $opp = $phase->opportunity;
+                    $emc = $opp->evaluationMethodConfiguration ?? null;
+                    if ($emc):
                         ?>
-                        <mc-tab label="<?= htmlspecialchars($emc->name) ?>" slug="valuers-<?= $phase->opportunity->id ?>">
+                        <mc-tab label="<?= htmlspecialchars($emc->name) ?>" slug="valuers-<?= $opp->id ?>">
                             <mc-card>
-                                <registration-evaluation-tab :phase-id="<?= $phase->opportunity->id ?>"></registration-evaluation-tab>
+                                <registration-evaluation-tab :phase-id="<?= (int) $opp->id ?>"></registration-evaluation-tab>
                             </mc-card>
                         </mc-tab>
-                    <?php $phase = $phase->nextPhase;
-                    endwhile ?>
+                    <?php
+                    endif;
+                    $appeal_opp = $opp->appealPhase ?? null;
+                    if ($appeal_opp && ($appeal_emc = $appeal_opp->evaluationMethodConfiguration ?? null)):
+                        ?>
+                        <mc-tab label="<?= htmlspecialchars($appeal_emc->name) ?>" slug="valuers-<?= $appeal_opp->id ?>">
+                            <mc-card>
+                                <registration-evaluation-tab :phase-id="<?= (int) $appeal_opp->id ?>"></registration-evaluation-tab>
+                            </mc-card>
+                        </mc-tab>
+                    <?php
+                    endif;
+                    $phase = $phase->nextPhase;
+                endwhile;
+                ?>
                 </mc-tabs>
             </div>
         </mc-tab>

--- a/src/modules/OpportunityAppealPhase/Module.php
+++ b/src/modules/OpportunityAppealPhase/Module.php
@@ -68,13 +68,17 @@ class Module extends \MapasCulturais\Module {
         $app->hook('POST(opportunity.createAppealPhaseRegistration)', function() use ($app, $self) {
             /** @var Controllers\Opportunity $this  */
 
-            $opportunity = $this->requestedEntity;
-            $appeal_phase = $opportunity->appealPhase;
+            try {
+                $opportunity = $this->requestedEntity;
+                $appeal_phase = $opportunity->appealPhase;
 
-            $data = $this->data;
-            $registration_id = $data['registration_id'] ?? 0;
-            
-            if ($registration_id) {
+                $data = $this->data;
+                $registration_id = $data['registration_id'] ?? 0;
+
+                if (!$registration_id) {
+                    $this->errorJson(i::__('ID da inscrição é obrigatório'), 400);
+                }
+
                 $registration = $app->repo('Registration')->findOneBy(['id' => $registration_id]);
 
                 if (!$registration) {
@@ -91,6 +95,17 @@ class Module extends \MapasCulturais\Module {
                 
                 if (!$appeal_phase) {
                     $this->errorJson(sprintf(i::__('Não existe uma fase de recurso para a %s'), $opportunity->name), 403);
+                }
+
+                // Verifica se já existe inscrição de recurso com o mesmo number
+                $existing_appeal = $app->repo('Registration')->findOneBy([
+                    'opportunity' => $appeal_phase,
+                    'number' => $registration->number
+                ]);
+
+                if ($existing_appeal) {
+                    $this->json($existing_appeal);
+                    return;
                 }
 
                 $new_registration = new \MapasCulturais\Entities\Registration();
@@ -126,6 +141,8 @@ class Module extends \MapasCulturais\Module {
                 }
 
                 $this->json($new_registration);
+            } catch (\MapasCulturais\Exceptions\PermissionDenied $e) {
+                $this->errorJson($e->getMessage(), 403);
             }
         });
 

--- a/src/modules/OpportunityAppealPhase/components/opportunity-appeal-phase-config/template.php
+++ b/src/modules/OpportunityAppealPhase/components/opportunity-appeal-phase-config/template.php
@@ -84,8 +84,8 @@ $this->import('
                 <div class="opportunity-appeal-phase-config__content-title">
                     <h3 class="bold"><?= i::__('Configuração da fase') ?></h3>
                     <div class="opportunity-appeal-phase-config__datepicker">
-                        <entity-field :entity="entity" prop="registrationFrom" field-type="date" label="<?= i::__('Início') ?>" :autosave="3000" :min="fromDateMin?._date" :max="fromDateMax?._date" classes="col-6 sm:col-12"></entity-field>
-                        <entity-field v-if="!firstPhase?.isContinuousFlow" field-type="date" label="<?= i::__('Término') ?>" :entity="entity" prop="registrationTo" :autosave="3000" :min="toDateMin?._date" :max="toDateMax?._date" classes="col-6 sm:col-12"></entity-field>
+                        <entity-field :entity="entity" prop="registrationFrom" label="<?= i::__('Início') ?>" :autosave="3000" :min="fromDateMin?._date" :max="fromDateMax?._date" classes="col-6 sm:col-12"></entity-field>
+                        <entity-field v-if="!firstPhase?.isContinuousFlow" label="<?= i::__('Término') ?>" :entity="entity" prop="registrationTo" :autosave="3000" :min="toDateMin?._date" :max="toDateMax?._date" classes="col-6 sm:col-12"></entity-field>
                     </div>
                 </div>
                 <div class="opportunity-appeal-phase-config__config-button">
@@ -130,12 +130,12 @@ $this->import('
                 <div class="opportunity-appeal-phase-config__content-title">
                     <h3 class="bold"><?= i::__('Configuração da fase') ?></h3>
                     <div class="opportunity-appeal-phase-config__datepicker">
-                        <entity-field :entity="entity.evaluationMethodConfiguration" prop="evaluationFrom" label="<?= i::__('Início') ?>" field-type="date" :autosave="3000" :min="fromDateMin?._date" :max="fromDateMax?._date" classes="col-6 sm:col-12"></entity-field>
-                        <entity-field v-if="!firstPhase?.isContinuousFlow" field-type="date" :entity="entity.evaluationMethodConfiguration" prop="evaluationTo" label="<?= i::__('Término') ?>" :autosave="3000" :min="toDateMin?._date" :max="toDateMax?._date" classes="col-6 sm:col-12"></entity-field>
+                        <entity-field :entity="entity.evaluationMethodConfiguration" prop="evaluationFrom" label="<?= i::__('Início') ?>" :autosave="3000" :min="fromDateMin?._date" :max="fromDateMax?._date" classes="col-6 sm:col-12"></entity-field>
+                        <entity-field v-if="!firstPhase?.isContinuousFlow" :entity="entity.evaluationMethodConfiguration" prop="evaluationTo" label="<?= i::__('Término') ?>" :autosave="3000" :min="toDateMin?._date" :max="toDateMax?._date" classes="col-6 sm:col-12"></entity-field>
                     </div>
                 </div>
                 <div class="opportunity-appeal-phase-config__checkboxes field">
-                    <entity-field class="input-box" :entity="entity" hide-required  :editable="true" prop="allow_proponent_response" :autosave="3000"></entity-field>
+                    <entity-field :entity="entity" hide-required  :editable="true" prop="allow_proponent_response" :autosave="3000"></entity-field>
                 </div> 
                 <div class="opportunity-appeal-phase-config__config-button opportunity-appeal-phase-config__add-evaluation-committee">
                     <opportunity-committee-groups :entity="entity.evaluationMethodConfiguration"></opportunity-committee-groups>

--- a/src/modules/OpportunityPhases/Module.php
+++ b/src/modules/OpportunityPhases/Module.php
@@ -111,6 +111,53 @@ class Module extends \MapasCulturais\Module{
     }
 
     /**
+     * Próxima fase na sequência do edital para validação de datas, ignorando fases de recurso.
+     * (Recursos são laterais à linha principal; não devem limitar o término das avaliações anteriores.)
+     */
+    public static function getNextPhaseForDateValidation(EvaluationMethodConfiguration $emc): EvaluationMethodConfiguration|Opportunity|null
+    {
+        $phase = $emc->opportunity;
+        $value = null;
+        while (!$value && ($phase = $phase->nextPhase)) {
+            if ($phase->isAppealPhase) {
+                continue;
+            }
+            if ($phase->isDataCollection || $phase->isLastPhase) {
+                $value = $phase;
+            } elseif ($childEmc = $phase->evaluationMethodConfiguration) {
+                $value = $childEmc;
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Data de término usada como limite superior na validação entre fases (fim de avaliação ou de coleta, conforme existir).
+     *
+     * @param Opportunity|EvaluationMethodConfiguration|null $phase
+     */
+    public static function getPhaseEndUpperBoundForValidation(EvaluationMethodConfiguration|Opportunity|null $phase): ?\DateTime
+    {
+        if ($phase === null) {
+            return null;
+        }
+        if ($phase instanceof EvaluationMethodConfiguration) {
+            return $phase->evaluationTo;
+        }
+        if ($phase->isLastPhase) {
+            return $phase->publishTimestamp;
+        }
+        if ($emc = $phase->evaluationMethodConfiguration) {
+            if ($emc->evaluationTo) {
+                return $emc->evaluationTo;
+            }
+        }
+
+        return $phase->registrationTo;
+    }
+
+    /**
      * Retorna a fase atual
      * @param Opportunity $base_opportunity
      * @return Opportunity
@@ -1372,7 +1419,18 @@ class Module extends \MapasCulturais\Module{
                 return;
             }
 
-            if ($next = $this->evaluationMethodConfiguration ?: $this->nextPhase ){
+            $next = $this->evaluationMethodConfiguration;
+            if (!$next) {
+                $walker = $this;
+                while ($n = $walker->nextPhase) {
+                    if (!$n->isAppealPhase) {
+                        $next = $n;
+                        break;
+                    }
+                    $walker = $n;
+                }
+            }
+            if ($next) {
                 if ($next->isLastPhase) {
                     $next_date_from = $next->publishTimestamp;
                     $next_date_to = $next->publishTimestamp;
@@ -1487,17 +1545,11 @@ class Module extends \MapasCulturais\Module{
                 $next_phase = $this->opportunity->lastPhase;
                 $error_message = i::__('A data final deve ser menor que a data de final de publicação dos resultados');
             } else {
-                $next_phase = $this->nextPhase;
+                $next_phase = self::getNextPhaseForDateValidation($this);
                 $error_message = i::__('A data final deve ser menor que a data de término da próxima fase');
             }
 
-            $date_to = null;
-
-            if($next_phase instanceof Opportunity) {
-                $date_to = $next_phase->isLastPhase ? $next_phase->publishTimestamp :  $next_phase->registrationTo;
-            } else if(is_object($next_phase)) {
-                $date_to = $next_phase->evaluationTo;
-            }
+            $date_to = self::getPhaseEndUpperBoundForValidation($next_phase);
 
             if($date_to) {
                 $date_to = $date_to->format('Y-m-d H:i:s');

--- a/src/modules/OpportunityPhases/Module.php
+++ b/src/modules/OpportunityPhases/Module.php
@@ -538,8 +538,17 @@ class Module extends \MapasCulturais\Module{
 
                         $app->applyHook('module(OpportunityPhases).evaluationPhaseData', [&$mout_simplify]);
 
-                        $item = $emc->simplify("{$mout_simplify},opportunity,infos,evaluationFrom,evaluationTo");
-                        $item->appealPhase = $emc->appealPhase;
+                        $item = $emc->simplify("{$mout_simplify},opportunity,infos,evaluationFrom,evaluationTo,relatedAgents,agentRelations");
+                        if($appeal_phase = $emc->appealPhase) {
+                            $item->appealPhase = $appeal_phase;
+                            $item->opportunity = $opportunity->simplify('id,isFirstPhase,isLastPhase,isReportingPhase,isLastReportingPhase,files,statusLabels,relatedAgents,agentRelations');
+                            $item->opportunity->appealPhase = (object) $appeal_phase->jsonSerialize();
+                            $item->opportunity->appealPhase->relatedAgents = $appeal_phase->relatedAgents;
+                            $item->opportunity->appealPhase->agentRelations = $appeal_phase->agentRelations;
+                            $item->opportunity->appealPhase->evaluationMethodConfiguration = (object) $appeal_phase->evaluationMethodConfiguration->jsonSerialize();
+                            $item->opportunity->appealPhase->evaluationMethodConfiguration->relatedAgents = $appeal_phase->evaluationMethodConfiguration->relatedAgents;
+                            $item->opportunity->appealPhase->evaluationMethodConfiguration->agentRelations = $appeal_phase->evaluationMethodConfiguration->agentRelations;
+                        }
 
                         $result[] = $item;
                     }

--- a/src/themes/BaseV2/assets-src/sass/2.components/_mc-stepper-vertical.scss
+++ b/src/themes/BaseV2/assets-src/sass/2.components/_mc-stepper-vertical.scss
@@ -359,6 +359,50 @@ ol.mc-stepper-vertical>li.active::before {
         p {
             font-weight: 600;
         }
+
+        .appeal-phase-info {
+            display: flex;
+            flex-direction: row;
+            align-items: flex-start;
+            margin: calc(size(24) * -1) size(8) size(12);
+            padding: size(6) size(10);
+            border: 0;
+            border-radius: 0 0 size(15) size(15);
+            background: var(--mc-white);
+            position: relative;
+            z-index: 0;
+            width: 90%;
+            justify-content: space-between;
+
+            &::before {
+                content: '';
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                height: 1px;
+                background: transparent;
+                opacity: .45;
+            }
+
+            .data-collection {
+                .data-collection-dates {
+                    display: flex;
+                    flex-direction: row;
+                    gap: size(4);
+                    justify-content: space-between;
+                }
+            }
+
+            .evaluation {
+                .evaluation-dates {
+                    display: flex;
+                    flex-direction: row;
+                    gap: size(4);
+                    justify-content: space-between;
+                }
+            }
+        }
     }
 
     .stepper-step {
@@ -585,4 +629,50 @@ ol.mc-stepper-vertical>li.active::before {
             flex-wrap: wrap;
         }
     }
+
+    .appeal-phase-info {
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+        margin: calc(size(24) * -1) size(8) size(12);
+        padding: size(6) size(10);
+        border: 0;
+        border-radius: 0 0 size(15) size(15);
+        background: var(--mc-white);
+        position: relative;
+        z-index: 0;
+        width: 90%;
+        justify-content: space-between;
+
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 1px;
+            background: transparent;
+            opacity: .45;
+        }
+
+        .data-collection {
+            .data-collection-dates {
+                display: flex;
+                flex-direction: row;
+                gap: size(4);
+                justify-content: space-between;
+            }
+        }
+
+        .evaluation {
+            .evaluation-dates {
+                display: flex;
+                flex-direction: row;
+                gap: size(4);
+                justify-content: space-between;
+            }
+        }
+    }
+
+    
 }


### PR DESCRIPTION
# #9326 Incorporar implementações 7.7.x (fase de recurso) + fix listagem de inscrições (previousPhase nulo)

## Milestones

- [x] Incorporar no fork as implementações da fase de recurso alinhadas ao fluxo 7.7.x (Mapas Culturais)
- [x] Ajustes de API e getter de fases (`Opportunity::phases`, endpoints relacionados à fase de recurso)
- [x] UI: steps verticais, abas de avaliadores, filtros de inscrição e avaliação contínua na fase de recurso
- [x] Validações de datas entre fases e exibição das datas de recurso
- [x] Correção da falha fatal na listagem administrativa de inscrições quando `previousPhase` não está resolvido

## Escopo técnico (resumo por commit, do mais recente ao mais antigo)

| Commit | Descrição |
|--------|-----------|
| `11b33c3` | **fix(core):** em `Opportunity::registerRegistrationMetadata()`, só chama `registerRegistrationMetadata()` na fase anterior se `previousPhase` existir; evita `Call to a member function registerRegistrationMetadata() on null` em `GET opportunity.registrations` (ex.: fase de recurso com `parent` definido e `previousPhase` nulo). |
| `82a9025` | Correção do formulário de **avaliação contínua** na fase de recurso. |
| `4a72b110` | Exibição das **datas de recurso** no step vertical de fases. |
| `d20e0ed` | **Validação de datas** entre fases com sequência lógica. |
| `536ba44` | Abas de avaliadores na single da inscrição incluem a **fase de recurso**. |
| `2556328` | Campos da fase de recurso nas opções do **filtro de inscrição** (avaliadores/comissão). |
| `c1d3531` | Endpoint **`createAppealPhaseRegistration`**: verifica se já existe inscrição do proponente na fase de recurso. |
| `70c56d6` | Correções no **carregamento de template**. |
| `dbafea9` | **`Opportunity::phases`**: retorno correto dos objetos da fase de recurso. |
| `25e8265` | Permite **solicitar recurso** em todos os status de inscrição aplicáveis na fase de recurso. |
