### PR TITLE
Corretiva 8147 Divergência Avaliação do Status da Inscrição

### DIFF
--- a/src/core/EvaluationMethod.php
+++ b/src/core/EvaluationMethod.php
@@ -184,7 +184,11 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
     function getTiebreakerEvaluation(Entities\Registration $registration) {
         $app = App::i();
 
-        $tiebreaker_evaluations = $app->repo('RegistrationEvaluation')->findOneBy(['registration' => $registration, 'isTiebreaker' => true]);
+        $tiebreaker_evaluations = $app->repo('RegistrationEvaluation')->findOneBy([
+            'registration' => $registration,
+            'isTiebreaker' => true,
+            'status' => RegistrationEvaluation::STATUS_SENT
+        ]);
 
         if(empty($tiebreaker_evaluations)){
             return null;

--- a/src/modules/Opportunities/Jobs/AutoApplicationResult.php
+++ b/src/modules/Opportunities/Jobs/AutoApplicationResult.php
@@ -42,10 +42,20 @@ class AutoApplicationResult extends JobType
         $all_status_sent = true;
 
         foreach ($evaluations as $evaluation) {
-            $registration_evaluation = $evaluation['evaluation_id'] ? $app->repo('RegistrationEvaluation')->find($evaluation['evaluation_id']) : false;
+            if ($evaluation['valuer_committee'] === '@tiebreaker') {
+                continue;
+            }
 
-            if (!$registration_evaluation && $evaluation['evaluation_status'] !== RegistrationEvaluation::STATUS_SENT) {
-                $all_status_sent = false;
+            if ($evaluation_type == 'continuous') {
+                if (!$evaluation['evaluation_id']) {
+                    $all_status_sent = false;
+                    break;
+                }
+            } else {
+                if ($evaluation['evaluation_status'] != RegistrationEvaluation::STATUS_SENT) {
+                    $all_status_sent = false;
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
A princípio seria uma correção exclusiva para o Cultura Viva. Porém o problema é interno de funcionalidades do core, e afeta não só processos do CulturaViva, mas também de outros temas que utilizam da funcionalidade.

Problema: o `AutoApplicationResult` usava uma condição com `&&` que verificava se o objeto da avaliação existia no banco antes de checar o status de envio. Como qualquer interação do avaliador (abrir, salvar rascunho, concluir) já criava o registro, o operador `&&` fazia *short-circuit* e nunca verificava se a avaliação tinha sido realmente enviada. Com isso, o sistema aplicava o resultado final da inscrição de forma prematura, considerando apenas as avaliações existentes — mesmo que fossem rascunhos ou estivessem incompletas. O mesmo tipo de problema existia no `getTiebreakerEvaluation`, que buscava a avaliação de desempate sem filtrar por status, permitindo que um rascunho do avaliador de desempate sobrescrevesse o resultado consolidado.

Correção: no `AutoApplicationResult`, a lógica foi substituída por uma verificação direta do `evaluation_status` da view SQL: para tipos normais (`simple`, `qualification`, `documentary`), exige-se que o status seja `SENT` (2); para o tipo `continuous` (que nunca chama `send()`), verifica-se apenas se o registro existe; e avaliadores `@tiebreaker` são ignorados no *loop*, pois já têm tratamento próprio no *guard* inicial do *job*. No `getTiebreakerEvaluation`, foi adicionado o filtro `status => STATUS_SENT` na busca, garantindo que apenas avaliações formalmente enviadas sejam consideradas no desempate.