### PR TITLE
9344 entity listed with blank name

### DIFF
--- a/src/modules/Components/components/select-entity/script.js
+++ b/src/modules/Components/components/select-entity/script.js
@@ -19,6 +19,8 @@ app.component('select-entity', {
     },
 
     created() {
+        this.applyDefaultNameFilter();
+
         switch (this.type) {
             case 'agent':
                 this.itensText = this.text('Selecione um dos agentes');
@@ -59,7 +61,7 @@ app.component('select-entity', {
         },
         query: {
             type: Object,
-            default: {}
+            default: () => ({})
         },
         permissions: {
             type: String,
@@ -98,6 +100,21 @@ app.component('select-entity', {
     },
     
     methods: {
+        applyDefaultNameFilter() {
+            const entityDescription = $DESCRIPTIONS?.[this.type];
+            const hasNameField = Boolean(entityDescription?.name);
+
+            if (!hasNameField) {
+                return;
+            }
+
+            if (Object.prototype.hasOwnProperty.call(this.query, 'name')) {
+                return;
+            }
+
+            this.query.name = 'AND(!NULL(),!EQ())';
+        },
+
         selectEntity(entity, close) {
             this.$emit('select', entity);
             close();

--- a/src/modules/Opportunities/components/opportunity-evaluation-committee/script.js
+++ b/src/modules/Opportunities/components/opportunity-evaluation-committee/script.js
@@ -18,25 +18,6 @@ app.component('opportunity-evaluation-committee', {
     },
 
     computed: {
-        query() {
-            let query = {
-                '@select': 'id,name,files.avatar,user',
-                '@order': 'id ASC',
-                '@limit': '25',
-                '@page': '1',
-                'type': 'EQ(1)',
-            };
-
-            if (this.reviewersId.length > 0) {
-                const ids = this.reviewersId.join(',');
-                query['id'] = `!IN(${ids})`;
-            } else {
-                delete query['id'];
-            }
-
-            return query;
-        },
-
         allExpanded() {
             return this.infosReviewers.every(reviewer => reviewer.isContentVisible);
         },
@@ -74,6 +55,13 @@ app.component('opportunity-evaluation-committee', {
             showReviewers: false,
             infosReviewers: [],
             queryString: 'id,name,files.avatar,user',
+            agentsQuery: {
+                '@select': 'id,name,files.avatar,user',
+                '@order': 'id ASC',
+                '@limit': '25',
+                '@page': '1',
+                type: 'EQ(1)',
+            },
             selectCategories: [],
             registrationCategories: [
                 'sem avaliações',
@@ -91,8 +79,27 @@ app.component('opportunity-evaluation-committee', {
             fetchFields: this.entity.fetchFields
         }
     },
+
+    watch: {
+        reviewersId: {
+            handler() {
+                this.syncAgentsQueryIdFilter();
+            },
+            deep: true,
+        },
+    },
     
     methods: {   
+        syncAgentsQueryIdFilter() {
+            if (this.reviewersId.length > 0) {
+                const ids = this.reviewersId.join(',');
+                this.agentsQuery.id = `!IN(${ids})`;
+                return;
+            }
+
+            delete this.agentsQuery.id;
+        },
+
         showSummary(summary) {
             return summary ? Object.values(summary).some(value => value > 0) : false;
         },
@@ -182,6 +189,7 @@ app.component('opportunity-evaluation-committee', {
                 this.infosReviewers = [...pendingReviews, ...acceptedReviews];
 
                 this.reviewersId = this.infosReviewers.map((reviewer) => reviewer.agent.id);
+                this.syncAgentsQueryIdFilter();
 
                 this.infosReviewers = this.infosReviewers.filter (reviewer => {
                     if (this.showDisabled) {

--- a/src/modules/Opportunities/components/opportunity-evaluation-committee/template.php
+++ b/src/modules/Opportunities/components/opportunity-evaluation-committee/template.php
@@ -19,7 +19,7 @@ $this->import('
 ?>
 <div class="opportunity-evaluation-committee">
     <div class="opportunity-evaluation-committee__header">
-        <select-entity v-if="!showDisabled" type="agent" :select="queryString" :query="query" @select="selectAgent($event)" openside="down-right" permissions="">
+        <select-entity v-if="!showDisabled" type="agent" :select="queryString" :query="agentsQuery" @select="selectAgent($event)" openside="down-right" permissions="">
             <template #button="{ toggle }">
                 <button class="button button--icon button--primary button--md" @click="toggle()">
                     <mc-icon name="add"></mc-icon>
@@ -156,7 +156,7 @@ $this->import('
     </div>
 
     <div class="opportunity-evaluation-committee__footer" v-if="infosReviewers.length > 0 && !showDisabled">
-        <select-entity type="agent" :select="queryString" :query="query" @select="selectAgent($event)" openside="down-right" permissions="">
+        <select-entity type="agent" :select="queryString" :query="agentsQuery" @select="selectAgent($event)" openside="down-right" permissions="">
             <template #button="{ toggle }">
                 <button class="button button--icon button--primary button--md" @click="toggle()">
                     <mc-icon name="add"></mc-icon>


### PR DESCRIPTION
## Contexto
Problemas na seleção de entidades/avaliadores, principalmente em cenários com nomes em branco e em buscas de comissão de avaliação.

<img width="813" height="641" alt="image" src="https://github.com/user-attachments/assets/c02d1e70-3052-4bf3-8d73-04c996ca2da0" />
<img width="1866" height="669" alt="image" src="https://github.com/user-attachments/assets/b1f2685e-a5f5-4125-b292-0d30fbaef90b" />


## O que foi ajustado

### 1) `select-entity`
- Aplicado filtro padrão de `name` quando o tipo da entidade possui campo de nome e o filtro ainda não foi informado.
- Esse filtro evita retorno de entidades com nome nulo/vazio.
- Ajustado `default` de `query` para factory function (`() => ({})`) para evitar compartilhamento de estado entre instâncias.

### 2) `opportunity-evaluation-committee`
- A query de busca de avaliadores foi estabilizada com um objeto reativo dedicado (`agentsQuery`), em vez de depender de `computed` mutável.
- Criado sincronismo do filtro de `id` (`!IN(...)`) com a lista atual de avaliadores já vinculados.
- Atualizado template para usar `agentsQuery` nos pontos de seleção de avaliadores.