### PR TITLE
Corretiva #9422 - Bug no perfil de Agente

### DIFF
--- a/src/conf/agent-types.php
+++ b/src/conf/agent-types.php
@@ -63,9 +63,6 @@ return array(
                 MapasCulturais\i::__('De 20.001,00 a 100.000,00'),
                 MapasCulturais\i::__('Acima de 100.000,00'),
             ),
-            'validations' => array(
-                'required' => \MapasCulturais\i::__('O campo Renda é obrigatório.')
-            ),
             'available_for_opportunities' => true,
         ),
 


### PR DESCRIPTION
## Contexto
Alguns perfis de agente não conseguiam publicar ou editar por erro de validação:  
`{"renda":["O campo Renda é obrigatório."]}`.
A causa era a validação `required` definida globalmente em `src/conf/agent-types.php`, enquanto em parte dos temas o campo não é exibido/solicitado nos fluxos de edição/publicação.
## Alteração aplicada
- Arquivo alterado: `src/conf/agent-types.php`
- Removido o bloco:
  - `validations.required` do metadata `renda`
## Impacto esperado
- Agentes podem ser publicados/editados sem preencher `renda` nos temas que não trabalham esse campo no formulário.
- Não há mudança funcional específica em telas de temas fora `Pnab`.