### PR TITLE
Corretiva O.S #9438 - Bug na Duplicação de Oportunidade

### DIFF
--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -14,15 +14,39 @@ trait EntityManagerModel {
 
         $this->requireAuthentication();
         $this->entityOpportunity = $this->requestedEntity;
-        $this->entityOpportunityModel = $this->generateModel();
 
-        $this->generateEvaluationMethods();
-        $this->generatePhases();
-        $this->generateMetadata();
-        $this->generateRegistrationFieldsAndFiles($this->entityOpportunity, $this->entityOpportunityModel);
-        $this->generateSealsRelations();
+        // Impede gerar modelo de oportunidade de outro subsite
+        $currentSubsiteId = $app->getCurrentSubsiteId();
+        $opportunitySubsiteId = $this->entityOpportunity->subsite ? $this->entityOpportunity->subsite->id : null;
+        if ($currentSubsiteId !== $opportunitySubsiteId) {
+            $this->errorJson(['message' => 'Não é possível gerar modelo de uma oportunidade de outro subsite.'], 403);
+            return;
+        }
 
-        $this->entityOpportunityModel->save(true);
+        self::$duplicating = true;
+        $app->em->beginTransaction();
+        try {
+            $this->entityOpportunityModel = $this->generateModel();
+
+            $this->generateEvaluationMethods();
+            $this->generatePhases();
+            $this->generateMetadata();
+            $this->generateRegistrationFieldsAndFiles($this->entityOpportunity, $this->entityOpportunityModel);
+            $this->generateSealsRelations();
+
+            // Remapeia referências a fases originais (appealPhase, etc.)
+            $this->modelRemapPhaseReferences();
+
+            $this->entityOpportunityModel->save(true);
+
+            $app->em->commit();
+        } catch (\Exception $e) {
+            $app->em->rollback();
+            self::$duplicating = false;
+            throw $e;
+        } finally {
+            self::$duplicating = false;
+        }
         
         if($this->isAjax()){
             $this->json($this->entityOpportunity);
@@ -37,17 +61,40 @@ trait EntityManagerModel {
         $this->requireAuthentication();
         $this->entityOpportunity = $this->requestedEntity;
 
+        // Impede gerar oportunidade a partir de modelo de outro subsite
+        $currentSubsiteId = $app->getCurrentSubsiteId();
+        $opportunitySubsiteId = $this->entityOpportunity->subsite ? $this->entityOpportunity->subsite->id : null;
+        if ($currentSubsiteId !== $opportunitySubsiteId) {
+            $this->errorJson(['message' => 'Não é possível gerar oportunidade a partir de um modelo de outro subsite.'], 403);
+            return;
+        }
+
         $app->disableAccessControl();
-        $this->entityOpportunityModel = $this->generateOpportunity();
+        self::$duplicating = true;
+        $app->em->beginTransaction();
+        try {
+            $this->entityOpportunityModel = $this->generateOpportunity();
 
-        $this->generateEvaluationMethods();
-        $this->generatePhases();
-        $this->generateMetadata(0, 0);
-        $this->generateRegistrationFieldsAndFiles($this->entityOpportunity, $this->entityOpportunityModel);
+            $this->generateEvaluationMethods();
+            $this->generatePhases();
+            $this->generateMetadata(0, 0);
+            $this->generateRegistrationFieldsAndFiles($this->entityOpportunity, $this->entityOpportunityModel);
 
-        $this->entityOpportunityModel->save(true);
-       
-        $app->enableAccessControl();
+            // Remapeia referências a fases originais (appealPhase, etc.)
+            $this->modelRemapPhaseReferences();
+
+            $this->entityOpportunityModel->save(true);
+
+            $app->em->commit();
+        } catch (\Exception $e) {
+            $app->em->rollback();
+            self::$duplicating = false;
+            $app->enableAccessControl();
+            throw $e;
+        } finally {
+            self::$duplicating = false;
+            $app->enableAccessControl();
+        }
 
         $this->json($this->entityOpportunityModel); 
     }
@@ -120,6 +167,14 @@ trait EntityManagerModel {
 
         $this->entityOpportunityModel = clone $this->entityOpportunity;
 
+        // Remove referência stale ao EvaluationMethodConfiguration original
+        $this->entityOpportunityModel->evaluationMethodConfiguration = null;
+
+        // Limpa coleção de metadata herdada do clone
+        $refMeta = new \ReflectionProperty($this->entityOpportunityModel, '__metadata');
+        $refMeta->setAccessible(true);
+        $refMeta->setValue($this->entityOpportunityModel, new \Doctrine\Common\Collections\ArrayCollection());
+
         $this->entityOpportunityModel->name = $name;
         $this->entityOpportunityModel->status = -1;
         $this->entityOpportunityModel->shortDescription = $description;
@@ -149,6 +204,15 @@ trait EntityManagerModel {
         $name = $postData['name'];
         
         $this->entityOpportunityModel = clone $this->entityOpportunity;
+
+        // Remove referência stale ao EvaluationMethodConfiguration original
+        $this->entityOpportunityModel->evaluationMethodConfiguration = null;
+
+        // Limpa coleção de metadata herdada do clone
+        $refMeta = new \ReflectionProperty($this->entityOpportunityModel, '__metadata');
+        $refMeta->setAccessible(true);
+        $refMeta->setValue($this->entityOpportunityModel, new \Doctrine\Common\Collections\ArrayCollection());
+
         $this->entityOpportunityModel->name = $name;
         $this->entityOpportunityModel->status = Entity::STATUS_DRAFT;
         $this->entityOpportunityModel->owner = $app->user->profile;
@@ -178,108 +242,257 @@ trait EntityManagerModel {
 
         if (isset($postData['objectType']) && isset($postData['ownerEntity'])) {
             $ownerEntity = $app->repo($postData['objectType'])->find($postData['ownerEntity']);
-            $app->em->beginTransaction();            
+            // Não abre transação própria — já está dentro da transação externa
+            // de ALL_generatemodel() ou ALL_generateopportunity()
             $app->em->getConnection()->update('opportunity', [
                     'object_type' => $ownerEntity->getClassName(), 
                     'object_id' => $ownerEntity->id
                 ], ['id' => $id]);
-
-            $app->em->commit();
         }
     }
 
     private function generateEvaluationMethods() : void
     {
+        $this->modelGenerateEvalMethodsOf($this->entityOpportunity, $this->entityOpportunityModel);
+    }
+
+    /**
+     * Mapa de IDs de fases originais para IDs de fases geradas.
+     */
+    private $modelPhaseMap = [];
+
+    private function generatePhases() : void
+    {
+        $app = App::i();
+        $this->modelPhaseMap = [];
+
+        // Duplica recursivamente todas as fases (filhas, netas, etc.)
+        $this->modelGeneratePhasesOf($this->entityOpportunity, $this->entityOpportunityModel);
+
+        // Copia publishTimestamp da lastPhase e duplica sub-fases
+        $this->modelCopyLastPhaseData();
+    }
+
+    /**
+     * Duplica recursivamente as fases filhas de $originalParent,
+     * atribuindo-as como filhas de $newParent.
+     */
+    private function modelGeneratePhasesOf($originalParent, $newParent) : void
+    {
         $app = App::i();
 
-        // duplica o método de avaliação para a oportunidade primária
-        $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
-            'opportunity' => $this->entityOpportunity
+        $phases = $app->repo('Opportunity')->findBy([
+            'parent' => $originalParent
         ]);
+
+        foreach ($phases as $phase) {
+            if ($phase->getMetadata('isLastPhase')) {
+                continue;
+            }
+
+            $newPhase = clone $phase;
+            $newPhase->setParent($newParent);
+            $newPhase->owner = $app->user->profile;
+
+            // Remove referência stale ao EvaluationMethodConfiguration original
+            $newPhase->evaluationMethodConfiguration = null;
+
+            // Desabilita o lock para evitar que o clone herde o lock do original
+            $newPhase->__lockEnable = false;
+
+            // Limpa coleção de metadata herdada do clone
+            $refMeta = new \ReflectionProperty($newPhase, '__metadata');
+            $refMeta->setAccessible(true);
+            $refMeta->setValue($newPhase, new \Doctrine\Common\Collections\ArrayCollection());
+
+            // Persiste o clone para obter um ID novo
+            $newPhase->save(true);
+
+            // Registra no mapa de fases
+            $this->modelPhaseMap[$phase->id] = $newPhase->id;
+
+            // duplica apenas os metadados realmente persistidos no banco
+            $persistedMeta = $app->repo($phase->getMetadataClassName())->findBy(['owner' => $phase]);
+            foreach ($persistedMeta as $metadataObject) {
+                $metadataValue = $metadataObject->value;
+                if (!is_null($metadataValue) && $metadataValue != '') {
+                    if (is_array($metadataValue)) {
+                        $metadataValue = json_encode($metadataValue);
+                    }
+                    $newPhase->setMetadata($metadataObject->key, $metadataValue);
+                }
+            }
+
+            $this->generateRegistrationFieldsAndFiles($phase, $newPhase);
+
+            $now = new \DateTime('now');
+            $newPhase->createTimestamp = $now;
+            $newPhase->subsite = $phase->subsite;
+
+            $newPhase->save(true);
+
+            $this->changeObjectType($newPhase->id);
+
+            // Duplica eval method configs
+            $this->modelGenerateEvalMethodsOf($phase, $newPhase);
+
+            // Duplica recursivamente sub-fases (ex: fases de recurso)
+            $this->modelGeneratePhasesOf($phase, $newPhase);
+        }
+    }
+
+    /**
+     * Duplica os EvaluationMethodConfigurations de $originalPhase para $newPhase.
+     */
+    private function modelGenerateEvalMethodsOf($originalPhase, $newPhase) : void
+    {
+        $app = App::i();
+
+        $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
+            'opportunity' => $originalPhase
+        ]);
+
         foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
             $newMethodConfiguration = clone $evaluationMethodConfiguration;
-            $newMethodConfiguration->setOpportunity($this->entityOpportunityModel);
+            $newMethodConfiguration->setOpportunity($newPhase);
+
+            $refMeta = new \ReflectionProperty($newMethodConfiguration, '__metadata');
+            $refMeta->setAccessible(true);
+            $refMeta->setValue($newMethodConfiguration, new \Doctrine\Common\Collections\ArrayCollection());
+
             $newMethodConfiguration->save(true);
 
-            // duplica os metadados das configurações do modelo de avaliação
-            foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
-                $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
+            // duplica apenas os metadados realmente persistidos no banco
+            $persistedMeta = $app->repo($evaluationMethodConfiguration->getMetadataClassName())->findBy(['owner' => $evaluationMethodConfiguration]);
+            foreach ($persistedMeta as $metadataObject) {
+                $metadataValue = $metadataObject->value;
+                if (is_array($metadataValue)) {
+                    $metadataValue = json_encode($metadataValue);
+                }
+                $newMethodConfiguration->setMetadata($metadataObject->key, $metadataValue);
                 $newMethodConfiguration->save(true);
             }
         }
     }
 
-    private function generatePhases() : void
+    /**
+     * Remapeia metadados que referenciam fases originais.
+     */
+    private function modelRemapPhaseReferences() : void
     {
+        if (empty($this->modelPhaseMap)) {
+            return;
+        }
+
         $app = App::i();
-        $postData = $this->postData;
+        $conn = $app->em->getConnection();
 
-        $phases = $app->repo('Opportunity')->findBy([
-            'parent' => $this->entityOpportunity
-        ]);
-        foreach ($phases as $phase) {
-            
-            if (!$phase->getMetadata('isLastPhase')) {
-                $newPhase = clone $phase;
-                $newPhase->setParent($this->entityOpportunityModel);
-                $newPhase->owner = $app->user->profile;
+        // Garante que todos os metadados pendentes estejam persistidos
+        $app->em->flush();
 
-                foreach ($phase->getMetadata() as $metadataKey => $metadataValue) {
-                    if (!is_null($metadataValue) && $metadataValue != '') {
-                        $newPhase->setMetadata($metadataKey, $metadataValue);
-                        $newPhase->save(true);
-                    }
-                }
+        $newIds = array_merge(
+            [$this->entityOpportunityModel->id],
+            array_values($this->modelPhaseMap)
+        );
 
-                $this->generateRegistrationFieldsAndFiles($phase, $newPhase);
+        $metaKeysToRemap = ['appealPhase'];
 
-                $now = new \DateTime('now');
-                $newPhase->createTimestamp = $now;
-                $newPhase->subsite = $phase->subsite;
+        foreach ($metaKeysToRemap as $metaKey) {
+            foreach ($newIds as $newId) {
+                $rows = $conn->fetchAll(
+                    "SELECT id, value FROM opportunity_meta WHERE object_id = ? AND key = ?",
+                    [$newId, $metaKey]
+                );
 
-                $newPhase->save(true);
-
-                $this->changeObjectType($newPhase->id);
-
-                $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
-                    'opportunity' => $phase
-                ]);
-
-                foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
-                    $newMethodConfiguration = clone $evaluationMethodConfiguration;
-                    $newMethodConfiguration->setOpportunity($newPhase);
-                    $newMethodConfiguration->save(true);
-
-                    // duplica os metadados das configurações do modelo de avaliação para a fase
-                    foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
-                        $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
-                        $newMethodConfiguration->save(true);
+                foreach ($rows as $row) {
+                    if (preg_match('/^(MapasCulturais\\\\Entities\\\\Opportunity):(\d+)$/', $row['value'], $matches)) {
+                        $oldRefId = (int) $matches[2];
+                        if (isset($this->modelPhaseMap[$oldRefId])) {
+                            $newRefId = $this->modelPhaseMap[$oldRefId];
+                            $newValue = $matches[1] . ':' . $newRefId;
+                            $conn->executeUpdate(
+                                "UPDATE opportunity_meta SET value = ? WHERE id = ?",
+                                [$newValue, $row['id']]
+                            );
+                        } else {
+                            // A fase referenciada não foi encontrada no mapa de duplicação.
+                            // Mantém o metadado como está e loga aviso para investigação.
+                            $app->log->warning("modelRemapPhaseReferences: opp $newId, metaKey '$metaKey' " .
+                                "referencia fase $oldRefId que não está no modelPhaseMap. Valor mantido.");
+                        }
                     }
                 }
             }
-            
+        }
+    }
 
+    /**
+     * Copia publishTimestamp e metadados da lastPhase, e duplica sub-fases.
+     */
+    private function modelCopyLastPhaseData() : void
+    {
+        $app = App::i();
+
+        $originalLastPhase = null;
+        $originalPhases = $app->repo('Opportunity')->findBy([
+            'parent' => $this->entityOpportunity
+        ]);
+        foreach ($originalPhases as $phase) {
             if ($phase->getMetadata('isLastPhase')) {
-                $publishDate = $phase->publishTimestamp;
-                $subsite = $phase->subsite;
+                $originalLastPhase = $phase;
+                break;
             }
         }
 
-        if (isset($publishDate)) {
-            $phases = $app->repo('Opportunity')->findBy([
-                'parent' => $this->entityOpportunityModel
-            ]);
-    
-            foreach ($phases as $phase) {
-                if ($phase->getMetadata('isLastPhase')) {
-                    $phase->setPublishTimestamp($publishDate);
-                    $phase->subsite = $subsite;
-                    $phase->save(true);
+        if (!$originalLastPhase) {
+            return;
+        }
 
-                    $this->changeObjectType($phase->id);
-                }
+        $newLastPhase = null;
+        $newPhases = $app->repo('Opportunity')->findBy([
+            'parent' => $this->entityOpportunityModel
+        ]);
+        foreach ($newPhases as $phase) {
+            if ($phase->getMetadata('isLastPhase')) {
+                $newLastPhase = $phase;
+                break;
             }
-        }   
+        }
+
+        if (!$newLastPhase) {
+            return;
+        }
+
+        if ($originalLastPhase->publishTimestamp) {
+            $newLastPhase->setPublishTimestamp($originalLastPhase->publishTimestamp);
+        }
+        $newLastPhase->subsite = $originalLastPhase->subsite;
+
+        // Copia metadados da lastPhase original
+        $persistedMeta = $app->repo($originalLastPhase->getMetadataClassName())->findBy(['owner' => $originalLastPhase]);
+        $hookDefinedKeys = ['isLastPhase', 'isOpportunityPhase', 'isDataCollection'];
+        foreach ($persistedMeta as $metadataObject) {
+            if (in_array($metadataObject->key, $hookDefinedKeys)) {
+                continue;
+            }
+            $metadataValue = $metadataObject->value;
+            if (!is_null($metadataValue) && $metadataValue != '') {
+                if (is_array($metadataValue)) {
+                    $metadataValue = json_encode($metadataValue);
+                }
+                $newLastPhase->setMetadata($metadataObject->key, $metadataValue);
+            }
+        }
+
+        $newLastPhase->save(true);
+
+        $this->changeObjectType($newLastPhase->id);
+
+        // Registra no mapa de fases
+        $this->modelPhaseMap[$originalLastPhase->id] = $newLastPhase->id;
+
+        // Duplica sub-fases da lastPhase
+        $this->modelGeneratePhasesOf($originalLastPhase, $newLastPhase);
     }
 
 
@@ -306,6 +519,10 @@ trait EntityManagerModel {
         $this->entityOpportunityModel->setMetadata('isModelPublic', $isModelPublic);
 
         $this->entityOpportunityModel->saveTerms();
+
+        // Persiste os metadados imediatamente para que modelRemapPhaseReferences()
+        // possa encontrá-los via SQL direto
+        $this->entityOpportunityModel->save(true);
     }
 
     private function generateRegistrationFieldsAndFiles($opportunityCurrent, $opportunityNew) : void

--- a/src/core/Traits/EntityOpportunityDuplicator.php
+++ b/src/core/Traits/EntityOpportunityDuplicator.php
@@ -10,24 +10,56 @@ trait EntityOpportunityDuplicator {
     private $entityOpportunity;
     private $entityNewOpportunity;
 
+    /**
+     * Flag que indica se o processo de duplicação está em andamento.
+     * Usado para desabilitar hooks que interferem na atribuição explícita
+     * de EvaluationMethodConfigurations durante a duplicação.
+     */
+    public static $duplicating = false;
+
     function ALL_duplicate(){
         $app = App::i();
 
         $this->requireAuthentication();
         $this->entityOpportunity = $this->requestedEntity;
-        $this->entityNewOpportunity = $this->cloneOpportunity();
 
+        // Impede duplicação de oportunidade de outro subsite
+        $currentSubsiteId = $app->getCurrentSubsiteId();
+        $opportunitySubsiteId = $this->entityOpportunity->subsite ? $this->entityOpportunity->subsite->id : null;
+        if ($currentSubsiteId !== $opportunitySubsiteId) {
+            $this->errorJson(['message' => 'Não é possível duplicar uma oportunidade de outro subsite.'], 403);
+            return;
+        }
 
-        $this->duplicateEvaluationMethods();
-        $this->duplicatePhases();
-        $this->duplicateMetadata();
-        $this->duplicateRegistrationFieldsAndFiles();
-        $this->duplicateMetalist();
-        $this->duplicateFiles();
-        $this->duplicateAgentRelations();
-        $this->duplicateSealsRelations();
+        self::$duplicating = true;
+        $app->em->beginTransaction();
+        try {
+            $this->entityNewOpportunity = $this->cloneOpportunity();
 
-        $this->entityNewOpportunity->save(true);
+            $this->duplicateEvaluationMethods();
+            $this->duplicatePhases();
+            $this->duplicateMetadata();
+            $this->duplicateRegistrationFieldsAndFiles();
+            $this->duplicateMetalist();
+            $this->duplicateFiles();
+            $this->duplicateAgentRelations();
+            $this->duplicateSealsRelations();
+
+            // Remapeia referências a fases originais (appealPhase, etc.)
+            // DEVE rodar DEPOIS de duplicateMetadata() pois esta copia os metadados do
+            // opportunity principal que podem conter referências a fases originais
+            $this->remapPhaseReferences();
+
+            $this->entityNewOpportunity->save(true);
+
+            $app->em->commit();
+        } catch (\Exception $e) {
+            $app->em->rollback();
+            self::$duplicating = false;
+            throw $e;
+        } finally {
+            self::$duplicating = false;
+        }
        
         if($this->isAjax()){
             $this->json($this->entityOpportunity);
@@ -41,6 +73,16 @@ trait EntityOpportunityDuplicator {
         $app = App::i();
 
         $this->entityNewOpportunity = clone $this->entityOpportunity;
+
+        // Remove referência stale ao EvaluationMethodConfiguration original
+        // para evitar que hooks interpretem incorretamente que o clone já possui um eval config
+        $this->entityNewOpportunity->evaluationMethodConfiguration = null;
+
+        // Limpa coleção de metadata herdada do clone para evitar que
+        // setMetadata encontre objetos do original e ignore valores iguais
+        $refMeta = new \ReflectionProperty($this->entityNewOpportunity, '__metadata');
+        $refMeta->setAccessible(true);
+        $refMeta->setValue($this->entityNewOpportunity, new \Doctrine\Common\Collections\ArrayCollection());
 
         $dateTime = new \DateTime();
         $now = $dateTime->format('d-m-Y H:i:s');
@@ -60,20 +102,121 @@ trait EntityOpportunityDuplicator {
 
     private function duplicateEvaluationMethods() : void
     {
+        $this->duplicateEvaluationMethodsOf($this->entityOpportunity, $this->entityNewOpportunity);
+    }
+
+    /**
+     * Mapa de IDs de fases originais para IDs de fases duplicadas.
+     * Preenchido durante duplicatePhases() e usado para remapear
+     * referências como appealPhase.
+     */
+    private $phaseMap = [];
+
+    private function duplicatePhases() : void
+    {
+        $this->phaseMap = [];
+
+        // Duplica recursivamente todas as fases (filhas, netas, etc.)
+        $this->duplicatePhasesOf($this->entityOpportunity, $this->entityNewOpportunity);
+
+        // Copia publishTimestamp da lastPhase original para a nova lastPhase
+        // e duplica sub-fases da lastPhase
+        $this->copyLastPhasePublishDate();
+    }
+
+    /**
+     * Duplica recursivamente as fases filhas de $originalParent,
+     * atribuindo-as como filhas de $newParent.
+     */
+    private function duplicatePhasesOf($originalParent, $newParent) : void
+    {
         $app = App::i();
 
-        // duplica o método de avaliação para a oportunidade primária
-        $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
-            'opportunity' => $this->entityOpportunity
+        $phases = $app->repo('Opportunity')->findBy([
+            'parent' => $originalParent
         ]);
+
+        foreach ($phases as $phase) {
+            if ($phase->getMetadata('isLastPhase')) {
+                // lastPhase é recriada automaticamente pelo hook; apenas copiar publishDate depois
+                continue;
+            }
+
+            $newPhase = clone $phase;
+            $newPhase->setParent($newParent);
+
+            // Remove referência stale ao EvaluationMethodConfiguration original
+            $newPhase->evaluationMethodConfiguration = null;
+
+            // Desabilita o lock para evitar que o clone herde o lock do original
+            $newPhase->__lockEnable = false;
+
+            // Limpa coleção de metadata herdada do clone para evitar que
+            // setMetadata encontre objetos do original e ignore valores iguais
+            $refMeta = new \ReflectionProperty($newPhase, '__metadata');
+            $refMeta->setAccessible(true);
+            $refMeta->setValue($newPhase, new \Doctrine\Common\Collections\ArrayCollection());
+
+            // Persiste o clone para obter um ID novo antes de setar metadata
+            $newPhase->save(true);
+
+            // Registra no mapa de fases
+            $this->phaseMap[$phase->id] = $newPhase->id;
+
+            // duplica apenas os metadados realmente persistidos no banco
+            $persistedMeta = $app->repo($phase->getMetadataClassName())->findBy(['owner' => $phase]);
+            foreach ($persistedMeta as $metadataObject) {
+                $metadataValue = $metadataObject->value;
+                if (!is_null($metadataValue) && $metadataValue != '') {
+                    if (is_array($metadataValue)) {
+                        $metadataValue = json_encode($metadataValue);
+                    }
+                    $newPhase->setMetadata($metadataObject->key, $metadataValue);
+                }
+            }
+
+            $newPhase->save(true);
+
+            // duplica os campos e arquivos de inscrição da fase
+            $this->duplicateRegistrationFieldsAndFiles($phase, $newPhase);
+
+            // duplica os modelos de avaliações das fases
+            $this->duplicateEvaluationMethodsOf($phase, $newPhase);
+
+            // Duplica recursivamente sub-fases (ex: fases de recurso que são filhas desta fase)
+            $this->duplicatePhasesOf($phase, $newPhase);
+        }
+    }
+
+    /**
+     * Duplica os EvaluationMethodConfigurations de $originalPhase para $newPhase.
+     */
+    private function duplicateEvaluationMethodsOf($originalPhase, $newPhase) : void
+    {
+        $app = App::i();
+
+        $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
+            'opportunity' => $originalPhase
+        ]);
+
         foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
             $newMethodConfiguration = clone $evaluationMethodConfiguration;
-            $newMethodConfiguration->setOpportunity($this->entityNewOpportunity);
+            $newMethodConfiguration->setOpportunity($newPhase);
+
+            $refMeta = new \ReflectionProperty($newMethodConfiguration, '__metadata');
+            $refMeta->setAccessible(true);
+            $refMeta->setValue($newMethodConfiguration, new \Doctrine\Common\Collections\ArrayCollection());
+
             $newMethodConfiguration->save(true);
 
-            // duplica os metadados das configurações do modelo de avaliação
-            foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
-                $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
+            // duplica apenas os metadados realmente persistidos no banco
+            $persistedMeta = $app->repo($evaluationMethodConfiguration->getMetadataClassName())->findBy(['owner' => $evaluationMethodConfiguration]);
+            foreach ($persistedMeta as $metadataObject) {
+                $metadataValue = $metadataObject->value;
+                if (is_array($metadataValue)) {
+                    $metadataValue = json_encode($metadataValue);
+                }
+                $newMethodConfiguration->setMetadata($metadataObject->key, $metadataValue);
                 $newMethodConfiguration->save(true);
             }
 
@@ -85,98 +228,174 @@ trait EntityOpportunityDuplicator {
         }
     }
 
-    private function duplicatePhases() : void
+    /**
+     * Remapeia metadados que referenciam fases originais para apontar
+     * para as fases duplicadas correspondentes.
+     * Formato: "MapasCulturais\Entities\Opportunity:XXXX"
+     */
+    private function remapPhaseReferences() : void
+    {
+        if (empty($this->phaseMap)) {
+            return;
+        }
+
+        $app = App::i();
+        $conn = $app->em->getConnection();
+
+        // Garante que todos os metadados pendentes estejam persistidos no banco
+        // antes de fazer queries SQL diretas
+        $app->em->flush();
+
+        // Coleta todos os IDs da nova árvore (oportunidade principal + todas as fases duplicadas)
+        $newIds = array_merge(
+            [$this->entityNewOpportunity->id],
+            array_values($this->phaseMap)
+        );
+
+        $metaKeysToRemap = ['appealPhase'];
+
+        foreach ($metaKeysToRemap as $metaKey) {
+            foreach ($newIds as $newId) {
+                $rows = $conn->fetchAll(
+                    "SELECT id, value FROM opportunity_meta WHERE object_id = ? AND key = ?",
+                    [$newId, $metaKey]
+                );
+
+                foreach ($rows as $row) {
+                    // Formato: "MapasCulturais\Entities\Opportunity:XXXX"
+                    if (preg_match('/^(MapasCulturais\\\\Entities\\\\Opportunity):(\d+)$/', $row['value'], $matches)) {
+                        $oldRefId = (int) $matches[2];
+                        if (isset($this->phaseMap[$oldRefId])) {
+                            $newRefId = $this->phaseMap[$oldRefId];
+                            $newValue = $matches[1] . ':' . $newRefId;
+                            $conn->executeUpdate(
+                                "UPDATE opportunity_meta SET value = ? WHERE id = ?",
+                                [$newValue, $row['id']]
+                            );
+                        } else {
+                            // A fase referenciada não foi encontrada no mapa de duplicação.
+                            // Mantém o metadado como está e loga aviso para investigação.
+                            $app->log->warning("remapPhaseReferences: opp $newId, metaKey '$metaKey' " .
+                                "referencia fase $oldRefId que não está no phaseMap. Valor mantido.");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Copia o publishTimestamp e metadados da lastPhase original para a nova lastPhase,
+     * e duplica sub-fases da lastPhase original (ex: fase de recurso).
+     */
+    private function copyLastPhasePublishDate() : void
     {
         $app = App::i();
 
-        $phases = $app->repo('Opportunity')->findBy([
+        // Busca a lastPhase original
+        $originalLastPhase = null;
+        $originalPhases = $app->repo('Opportunity')->findBy([
             'parent' => $this->entityOpportunity
         ]);
-        foreach ($phases as $phase) {
-            if (!$phase->getMetadata('isLastPhase')) {
-                $newPhase = clone $phase;
-                $newPhase->setParent($this->entityNewOpportunity);
-
-                // duplica os metadados das fases
-                foreach ($phase->getMetadata() as $metadataKey => $metadataValue) {
-                    if (!is_null($metadataValue) && $metadataValue != '') {
-                        $newPhase->setMetadata($metadataKey, $metadataValue);
-                        $newPhase->save(true);
-                    }
-                }
-
-                $newPhase->save(true);
-
-                // duplica os modelos de avaliações das fases
-                $evaluationMethodConfigurations = $app->repo('EvaluationMethodConfiguration')->findBy([
-                    'opportunity' => $phase
-                ]);
-
-                foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
-                    $newMethodConfiguration = clone $evaluationMethodConfiguration;
-                    $newMethodConfiguration->setOpportunity($newPhase);
-                    $newMethodConfiguration->save(true);
-
-                    // duplica os metadados das configurações do modelo de avaliação para a fase
-                    foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
-                        $newMethodConfiguration->setMetadata($metadataKey, $metadataValue);
-                        $newMethodConfiguration->save(true);
-                    }
-
-                    foreach ($evaluationMethodConfiguration->getAgentRelations() as $agentRelation_) {
-                        $agentRelation = clone $agentRelation_;
-                        $agentRelation->owner = $newMethodConfiguration;
-                        $agentRelation->save(true);
-                    }
-                }
-            }
-
+        foreach ($originalPhases as $phase) {
             if ($phase->getMetadata('isLastPhase')) {
-                $publishDate = $phase->publishTimestamp;
+                $originalLastPhase = $phase;
+                break;
             }
         }
 
-        if (isset($publishDate)) {
-            $phases = $app->repo('Opportunity')->findBy([
-                'parent' => $this->entityNewOpportunity
-            ]);
-    
-            foreach ($phases as $phase) {
-                if ($phase->getMetadata('isLastPhase')) {
-                    $phase->setPublishTimestamp($publishDate);
-                    $phase->save(true);
-                }
+        if (!$originalLastPhase) {
+            return;
+        }
+
+        // Busca a nova lastPhase
+        $newLastPhase = null;
+        $newPhases = $app->repo('Opportunity')->findBy([
+            'parent' => $this->entityNewOpportunity
+        ]);
+        foreach ($newPhases as $phase) {
+            if ($phase->getMetadata('isLastPhase')) {
+                $newLastPhase = $phase;
+                break;
             }
-        }       
+        }
+
+        if (!$newLastPhase) {
+            return;
+        }
+
+        // Copia publishTimestamp
+        if ($originalLastPhase->publishTimestamp) {
+            $newLastPhase->setPublishTimestamp($originalLastPhase->publishTimestamp);
+        }
+
+        // Copia metadados da lastPhase original (exceto os já definidos pelo hook)
+        $persistedMeta = $app->repo($originalLastPhase->getMetadataClassName())->findBy(['owner' => $originalLastPhase]);
+        $hookDefinedKeys = ['isLastPhase', 'isOpportunityPhase', 'isDataCollection'];
+        foreach ($persistedMeta as $metadataObject) {
+            if (in_array($metadataObject->key, $hookDefinedKeys)) {
+                continue;
+            }
+            $metadataValue = $metadataObject->value;
+            if (!is_null($metadataValue) && $metadataValue != '') {
+                if (is_array($metadataValue)) {
+                    $metadataValue = json_encode($metadataValue);
+                }
+                $newLastPhase->setMetadata($metadataObject->key, $metadataValue);
+            }
+        }
+
+        $newLastPhase->save(true);
+
+        // Registra no mapa de fases
+        $this->phaseMap[$originalLastPhase->id] = $newLastPhase->id;
+
+        // Duplica sub-fases da lastPhase original (ex: fase de recurso)
+        $this->duplicatePhasesOf($originalLastPhase, $newLastPhase);
     }
 
     private function duplicateMetadata() : void
     {
-        foreach ($this->entityOpportunity->getMetadata() as $metadataKey => $metadataValue) {
+        $app = App::i();
+
+        // duplica apenas os metadados realmente persistidos no banco
+        $persistedMeta = $app->repo($this->entityOpportunity->getMetadataClassName())->findBy(['owner' => $this->entityOpportunity]);
+        foreach ($persistedMeta as $metadataObject) {
+            $metadataValue = $metadataObject->value;
             if (!is_null($metadataValue) && $metadataValue != '') {
-                $this->entityNewOpportunity->setMetadata($metadataKey, $metadataValue);
+                if (is_array($metadataValue)) {
+                    $metadataValue = json_encode($metadataValue);
+                }
+                $this->entityNewOpportunity->setMetadata($metadataObject->key, $metadataValue);
             }
         }
 
         $this->entityNewOpportunity->setTerms(['area' => $this->entityOpportunity->terms['area']]);
         $this->entityNewOpportunity->setTerms(['tag' => $this->entityOpportunity->terms['tag']]);
         $this->entityNewOpportunity->saveTerms();
+
+        // Persiste os metadados imediatamente para que remapPhaseReferences()
+        // possa encontrá-los via SQL direto
+        $this->entityNewOpportunity->save(true);
     }
    
-    private function duplicateRegistrationFieldsAndFiles(): void
+    private function duplicateRegistrationFieldsAndFiles($sourceOpportunity = null, $targetOpportunity = null): void
     {
+        $sourceOpportunity = $sourceOpportunity ?? $this->entityOpportunity;
+        $targetOpportunity = $targetOpportunity ?? $this->entityNewOpportunity;
+
         // Criando um mapa de steps originais para os novos steps
         $stepMap = [];
         $fieldNameMap = []; // mapeamento de fieldName antigo (field_XXX) para novo (field_YYY)
 
         // Mapeando os steps existentes na nova Oportunidade
-        $existingSteps = array_column($this->entityNewOpportunity->registrationSteps->toArray(), null, 'id');
+        $existingSteps = array_column($targetOpportunity->registrationSteps->toArray(), null, 'id');
 
-        foreach ($this->entityOpportunity->registrationSteps as $oldStep) {
+        foreach ($sourceOpportunity->registrationSteps as $oldStep) {
             // Reutilizando step existente ou criar um novo
-            $stepMap[$oldStep->id] = $existingSteps[$oldStep->id] ?? (function () use ($oldStep) {
+            $stepMap[$oldStep->id] = $existingSteps[$oldStep->id] ?? (function () use ($oldStep, $targetOpportunity) {
                 $newStep = clone $oldStep;
-                $newStep->setOpportunity($this->entityNewOpportunity);
+                $newStep->setOpportunity($targetOpportunity);
                 $newStep->save(true);
                 return $newStep;
             })();
@@ -185,14 +404,14 @@ trait EntityOpportunityDuplicator {
         // Clonar campos e criar mapeamento de fieldName
         $conditionalFieldsToUpdate = [];
         
-        foreach ($this->entityOpportunity->getRegistrationFieldConfigurations() as $oldFieldConfiguration) {
+        foreach ($sourceOpportunity->getRegistrationFieldConfigurations() as $oldFieldConfiguration) {
             $oldFieldName = $oldFieldConfiguration->getFieldName();
             
             // Guardar conditional_field original antes de clonar
             $originalConditionalField = $oldFieldConfiguration->conditionalField;
             
             $newFieldConfiguration = clone $oldFieldConfiguration;
-            $newFieldConfiguration->setOwnerId($this->entityNewOpportunity->id);
+            $newFieldConfiguration->setOwnerId($targetOpportunity->id);
 
             // Atualizando o Step garantindo a correspondência correta
             if (isset($stepMap[$oldFieldConfiguration->step->id])) {
@@ -231,12 +450,12 @@ trait EntityOpportunityDuplicator {
         // Clonar arquivos e atualizar conditional_field
         $conditionalFilesToUpdate = [];
         
-        foreach ($this->entityOpportunity->getRegistrationFileConfigurations() as $oldFileConfiguration) {
+        foreach ($sourceOpportunity->getRegistrationFileConfigurations() as $oldFileConfiguration) {
             // Guardar conditional_field original antes de clonar
             $originalConditionalField = $oldFileConfiguration->conditionalField;
             
             $newFileConfiguration = clone $oldFileConfiguration;
-            $newFileConfiguration->setOwnerId($this->entityNewOpportunity->id);
+            $newFileConfiguration->setOwnerId($targetOpportunity->id);
 
             // Atualizando o Step garantindo a correspondência correta
             if (isset($stepMap[$oldFileConfiguration->step->id])) {

--- a/src/modules/OpportunityPhases/Module.php
+++ b/src/modules/OpportunityPhases/Module.php
@@ -1577,6 +1577,12 @@ class Module extends \MapasCulturais\Module{
          * é criada para "abrigar" a fase de avaliaçao.
          */
         $app->hook('entity(EvaluationMethodConfiguration).insert:before', function () {
+            // Pula durante duplicação de oportunidade - o duplicador gerencia
+            // explicitamente a atribuição de EvaluationMethodConfigurations às fases
+            if (\MapasCulturais\Controllers\Opportunity::$duplicating ?? false) {
+                return;
+            }
+
             $phase = null;
             $phases = $this->opportunity->allPhases;
 


### PR DESCRIPTION
## Resumo

Ajusta a duplicação de oportunidades.

O fluxo apresentava falhas em diferentes cenários, como erro de constraint única, conversão de array para string, problema com lock da entidade e persistência parcial de dados quando alguma etapa da duplicação falhava.

A lógica de duplicação foi revisada nos traits `EntityOpportunityDuplicator` e `EntityManagerModel`, com foco em copiar corretamente a estrutura da oportunidade e garantir que o processo seja executado de forma transacional.

## Problemas identificados

Durante a duplicação, alguns dados não eram copiados corretamente ou causavam falhas dependendo da estrutura da oportunidade:

- Conflito na criação de `EvaluationMethodConfiguration`, pois um hook criava a configuração automaticamente e o duplicador tentava criá-la novamente;
- Metadados com valores em array geravam erro de conversão para string;
- Alguns metadados do clone não eram atualizados corretamente após o `clone`;
- Fases filhas de outros níveis não eram copiadas, pois a duplicação considerava apenas o primeiro nível;
- O metadado `appealPhase` continuava apontando para a fase da oportunidade original;
- O mecanismo de lock podia impedir o salvamento da oportunidade duplicada;
- A `lastPhase` podia ficar sem metadados e sem suas fases vinculadas;
- Campos de formulário de fases filhas não eram copiados;
- Oportunidades de outro subsite podiam gerar erro ao tentar duplicar metadados não registrados no subsite atual;
- Em caso de falha no meio do processo, os dados já persistidos permaneciam no banco.

## O que foi alterado

A duplicação de fases passou a ser feita de forma recursiva, permitindo copiar toda a árvore de fases da oportunidade, independentemente da profundidade.

Durante esse processo, é criado um mapa relacionando o ID da fase original com o ID da nova fase. Esse mapa é usado para atualizar referências internas, como o metadado `appealPhase`, apontando corretamente para a nova estrutura duplicada.

Também foram feitos ajustes no processo de clonagem da oportunidade e das fases:

- Remoção da referência direta para `evaluationMethodConfiguration`;
- Desativação do lock durante a duplicação;
- Persistência do clone antes da cópia dos metadados, garantindo que a nova entidade já tenha ID próprio.

A cópia dos metadados agora considera apenas os registros persistidos no banco, evitando copiar valores calculados ou defaults retornados por `getMetadata()`.

Todo o processo de duplicação foi envolvido em transação. Caso alguma etapa falhe, é feito rollback e nenhuma parte da duplicação permanece gravada.

Também foi adicionada uma validação para impedir a duplicação de oportunidades pertencentes a outro subsite.

Durante a duplicação, o hook `entity(EvaluationMethodConfiguration).insert:before` passa a ignorar a criação automática quando `Opportunity::$duplicating === true`, evitando conflito com a cópia explícita da configuração.

Além disso, foi removida uma transação interna redundante em `changeObjectType()`, que podia causar inconsistência no controle de transações caso o `UPDATE` falhasse.

## Arquivos alterados

- `src/core/Traits/EntityOpportunityDuplicator.php`
- `src/core/Traits/EntityManagerModel.php`
- `src/modules/OpportunityPhases/Module.php`

## Como foi testado

- Duplicação de oportunidade com 4 fases, 2 sub-fases.
- Validação da cópia completa da árvore de fases;
- Validação do remapeamento do metadado `appealPhase`;
- Validação da cópia dos campos de formulário das fases;
- Simulação de erro durante a duplicação para confirmar o rollback;
- Tentativa de duplicação de oportunidade de outro subsite;
- Criação de novas oportunidades a partir de modelos, garantindo que o ajuste não impacta esse fluxo;
- Execução dos testes nos temas MapaMinC, PNAB e Funarte, para validar o comportamento da duplicação e da criação por modelo em diferentes contextos.