### PR TITLE
fix: evita erro ao exibir avaliação anterior de recurso

### DIFF
--- a/src/modules/Opportunities/components/registration-results/script.js
+++ b/src/modules/Opportunities/components/registration-results/script.js
@@ -40,7 +40,7 @@ app.component('registration-results', {
         },
 
         canShowAppeal() {
-            if (this.registration.opportunity.isReportingPhase) {
+            if (!this.registration?.opportunity || this.registration.opportunity.isReportingPhase) {
                 return false;
             }
             return this.registration.status > 1 && this.registration.status <= 10;
@@ -51,7 +51,7 @@ app.component('registration-results', {
         },
 
         modalTitle() {
-            return this.registration.opportunity.status === -20 ? 
+            return this.registration?.opportunity?.status === -20 ?
                 `${this.text('Detalhamento do recurso para ')} ${this.phase.name} - ${this.registration.number}` :
                 `${this.phase.name} - ${this.registration.number}`;
         },


### PR DESCRIPTION
## Resumo

Corrige erro na tela de avaliação de recurso ao exibir o detalhamento da avaliação da fase anterior.

## Problema

Na tela de avaliação, o componente `registration-results` pode receber uma inscrição da fase anterior sem o objeto `registration.opportunity` populado.

Quando isso acontece, o render quebra ao acessar diretamente:

```js
this.registration.opportunity.status
```

Erro observado no console:

```txt
TypeError: Cannot read properties of undefined (reading 'status')
```

## Solução

Ajusta o componente `registration-results` para tratar inscrições sem `opportunity` populada:

- adiciona guarda em `canShowAppeal`;
- usa optional chaining em `modalTitle` ao acessar `registration.opportunity.status`.

## Arquivo alterado

- `src/modules/Opportunities/components/registration-results/script.js`
