### PR TITLE
fix: upload permissions check before save file

### DIFF
--- a/src/modules/OpportunityWorkplan/Entities/Delivery.php
+++ b/src/modules/OpportunityWorkplan/Entities/Delivery.php
@@ -101,6 +101,70 @@ class Delivery extends \MapasCulturais\Entity {
         ];
     }
 
+    /**
+     * Verifica se o usuário pode modificar esta entrega.
+     *
+     * Além da verificação padrão de dono (EntityOwnerAgent._canUser),
+     * também permite se o usuário está preenchendo uma fase de monitoramento
+     * (prestação de informações) vinculada ao plano de trabalho desta entrega.
+     */
+    protected function canUserModify($user) {
+        // 1. Verificação padrão de dono via EntityOwnerAgent
+        if ($this->_canUser($user, 'modify')) {
+            return true;
+        }
+
+        // 2. Atravessa a cadeia Delivery → Goal → Workplan → Registration
+        $goal = $this->goal;
+        if (!$goal) {
+            return false;
+        }
+
+        $workplan = $goal->workplan;
+        if (!$workplan) {
+            return false;
+        }
+
+        $registration = $workplan->registration;
+        if (!$registration) {
+            return false;
+        }
+
+        // 3. Procura fases de monitoramento onde o usuário está preenchendo.
+        //    Monitoring registrations têm o mesmo número da original mas estão
+        //    na oportunidade de reporting phase (isReportingPhase = true).
+        $app = \MapasCulturais\App::i();
+
+        // Oportunidade original (first phase)
+        $original_opportunity = $registration->opportunity->firstPhase
+            ?: $registration->opportunity;
+
+        // Oportunidades filhas que são fases de prestação de informações
+        $children_opportunities = $original_opportunity->getChildren();
+        $reporting_opportunity_ids = [];
+
+        foreach ($children_opportunities as $child) {
+            if ($child->isReportingPhase) {
+                $reporting_opportunity_ids[] = $child->id;
+            }
+        }
+
+        if (!empty($reporting_opportunity_ids)) {
+            $monitoring_registrations = $app->repo('Registration')->findBy([
+                'opportunity' => $reporting_opportunity_ids,
+                'number'      => $registration->number,
+            ]);
+
+            foreach ($monitoring_registrations as $monitoring) {
+                if ($monitoring->canUser('modify', $user)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     public function jsonSerialize(): array
     {
         $metadatas = $this->getMetadata();

--- a/src/modules/OpportunityWorkplan/Module.php
+++ b/src/modules/OpportunityWorkplan/Module.php
@@ -288,6 +288,7 @@ class Module extends \MapasCulturais\Module{
                 $this->jsObject['EntitiesDescription']['workplan'] = Workplan::getPropertiesMetadata();
                 $this->jsObject['EntitiesDescription']['workplan']['goal'] = Goal::getPropertiesMetadata();
                 $this->jsObject['EntitiesDescription']['workplan']['goal']['delivery'] = Delivery::getPropertiesMetadata();
+                $this->jsObject['EntitiesDescription']['delivery'] = Delivery::getPropertiesMetadata();
             });
 
             // FALTA-1: Export workplan data in registration spreadsheets

--- a/src/modules/OpportunityWorkplan/components/registration-workplan/init.php
+++ b/src/modules/OpportunityWorkplan/components/registration-workplan/init.php
@@ -9,3 +9,4 @@ $this->jsObject['workplan'] = $app->_config['workplan'] ?? [];
 $this->jsObject['EntitiesDescription']['workplan'] = Workplan::getPropertiesMetadata();
 $this->jsObject['EntitiesDescription']['workplan']['goal'] = Goal::getPropertiesMetadata();
 $this->jsObject['EntitiesDescription']['workplan']['goal']['delivery'] = Delivery::getPropertiesMetadata();
+$this->jsObject['EntitiesDescription']['delivery'] = Delivery::getPropertiesMetadata();


### PR DESCRIPTION
 ### 🔴 Causa raiz do erro 403

 O upload falha na cadeia de permissão:

 ```
   File::canUserCreate()
     → $this->owner->canUser('modify')   // $this->owner = Delivery
       → genericPermissionVerification()  // só verifica: admin, ownerUser, agentRelation
 ```

 O Delivery não tinha um método canUserModify próprio — usava o genericPermissionVerification
 da classe base, que é mais restritivo que o _canUser do EntityOwnerAgent (não verifica
 $this->owner->userHasControl($user)).

 Além disso, genericPermissionVerification não considerava o contexto de monitoramento: o
 usuário está preenchendo uma inscrição filha (fase de prestação de informações), não a
 inscrição original dona do workplan.

 ### ✅ Correção aplicada

 Arquivo: src/modules/OpportunityWorkplan/Entities/Delivery.php

 Adicionei o método canUserModify($user) que verifica nesta ordem:
```
 ┌───────┬─────────────────────────────────────────────┬──────────────────────────────────────┐
 │ Passo │ Verificação                                 │ Quando concede                       │
 ├───────┼─────────────────────────────────────────────┼──────────────────────────────────────┤
 │ 1     │ EntityOwnerAgent::_canUser()                │ Dono, admin, ou tem controle sobre o │
 │       │                                             │ agente dono                          │
 ├───────┼─────────────────────────────────────────────┼──────────────────────────────────────┤
 │ 2     │ Atravessa a cadeia Delivery → Goal →        │ —                                    │
 │       │ Workplan → Registration                     │                                      │
 ├───────┼─────────────────────────────────────────────┼──────────────────────────────────────┤
 │ 3     │ Busca fases de monitoramento                │ Inscrição de monitoramento com mesmo │
 │       │ (isReportingPhase = true) filhas da         │ number da original E usuário pode    │
 │       │ oportunidade original                       │ modificá-la (status draft + owner)   │
 └───────┴─────────────────────────────────────────────┴──────────────────────────────────────┘
```
 O passo 3 é o que resolve o caso do monitoramento: a inscrição de monitoramento está em
 rascunho (STATUS_DRAFT), então Registration::canUserModify() retorna true para o proponente,
 destravando o upload.

 ### ⚡ Performance

 O framework já usa cache de permissões (app.usePermissionsCache), então a query de
 monitoramento só executa uma vez por usuário+entrega.
