### PR TITLE
Corrige coluna "Snapshot do plano de trabalho" com arrays na exportação Excel/HTML

### DIFF
--- a/src/modules/OpportunityWorkplan/Module.php
+++ b/src/modules/OpportunityWorkplan/Module.php
@@ -349,6 +349,8 @@ class Module extends \MapasCulturais\Module{
                     return;
                 }
 
+                try {
+
                 $regIds = array_map(function($row) { return $row['id']; }, $result);
 
                 $em = $app->em;
@@ -400,12 +402,18 @@ class Module extends \MapasCulturais\Module{
                             return implode(', ', array_filter($parts));
                         }
                     }
+                    if (is_object($val)) {
+                        $encoded = @json_encode($val, JSON_UNESCAPED_UNICODE);
+                        if ($encoded !== false) return $encoded;
+                        return '';
+                    }
                     return (string) $val;
                 };
 
                 $formatBool = function($val) {
                     if ($val === null || $val === '') return 'Não';
                     if (is_bool($val)) return $val ? 'Sim' : 'Não';
+                    if (is_object($val)) return 'Não';
                     $lower = strtolower((string) $val);
                     return $lower === 'true' ? 'Sim' : 'Não';
                 };
@@ -576,6 +584,10 @@ class Module extends \MapasCulturais\Module{
                     $row['workplan_deliveryDocumentationTypes'] = implode(' | ', array_filter($deliveryDocumentationTypes)) ?: '';
                 }
                 unset($row);
+
+                } catch (\Throwable $e) {
+                    $app->log->error("SpreadsheetJob getBatch:after - workplan fields failed: {$e->getMessage()}");
+                }
             });
         });
     }

--- a/src/modules/ProjectMonitoring/Module.php
+++ b/src/modules/ProjectMonitoring/Module.php
@@ -144,6 +144,61 @@ class Module extends \MapasCulturais\Module {
             }
         });
 
+        // Formata campos JSON complexos como texto legível nas exportações HTML/Excel
+        $formatSnapshot = function ($snapshot): string {
+            $goals = $snapshot->goals ?? [];
+            if (empty($goals)) {
+                return i::__('(sem metas)');
+            }
+
+            $status_labels = [
+                0  => i::__('programada'),
+                1  => i::__('em andamento'),
+                2  => i::__('atrasada'),
+                3  => i::__('cancelada'),
+                10 => i::__('concluída'),
+            ];
+
+            $status_counts = [];
+            $total_deliveries = 0;
+
+            foreach ($goals as $goal) {
+                $status = $goal->status ?? 0;
+                $label = $status_labels[$status] ?? (string) $status;
+                $status_counts[$label] = ($status_counts[$label] ?? 0) + 1;
+                $total_deliveries += count($goal->deliveries ?? []);
+            }
+
+            $total_goals = count($goals);
+            $parts = [];
+            foreach ($status_counts as $label => $count) {
+                $parts[] = "$count $label";
+            }
+
+            $summary = "$total_goals " . i::__('meta(s)') . ' — ' . implode(', ', $parts);
+            $summary .= ' (' . "$total_deliveries " . i::__('entrega(s) total') . ')';
+
+            return $summary;
+        };
+
+        $formatFields = function (&$hook_data) use ($formatSnapshot) {
+            foreach ($hook_data['data'] as &$entity) {
+                if (!empty($entity['workplanSnapshot']) && is_object($entity['workplanSnapshot'])) {
+                    $entity['workplanSnapshot'] = $formatSnapshot($entity['workplanSnapshot']);
+                }
+                if (!empty($entity['goalStatuses']) && (is_object($entity['goalStatuses']) || is_array($entity['goalStatuses']))) {
+                    $gs = (array) $entity['goalStatuses'];
+                    $entity['goalStatuses'] = ($gs[10] ?? 0) . '/' . ($gs['numGoals'] ?? 0) . ' ' . i::__('concluídas');
+                }
+                if (!empty($entity['workplanProxy']) && (is_object($entity['workplanProxy']) || is_array($entity['workplanProxy']))) {
+                    $entity['workplanProxy'] = json_encode($entity['workplanProxy'], JSON_UNESCAPED_UNICODE);
+                }
+            }
+        };
+
+        $app->hook('api.response(html).array(Entities):before', $formatFields);
+        $app->hook('api.response(excel).array(Entities):before', $formatFields);
+
     }
 
     public function register() {


### PR DESCRIPTION
 ### Problema

 Ao exportar inscrições via API (@type=excel ou @type=html), as colunas workplanSnapshot ("Snapshot do plano de trabalho"), goalStatuses ("Status das metas") e workplanProxy ("Registro de plano de trabalho") apareciam com arrays aninhados e tabelas HTML recursivas dentro das células, tornando os dados ilegíveis.

 ### Causa raiz

 Esses três campos são metadados do tipo json registrados no módulo ProjectMonitoring. A função unserialize retorna objetos PHP complexos (stdClass com arrays aninhados — goals → deliveries → files). Quando o renderizador HTML/Excel (src/core/ApiOutputs/Html.php) encontrava um valor que é objeto/array sem corresponder aos padrões conhecidos (referência a entidade, array plano de strings, etc.), ele caía no fallback:

 ```php
   // printBodyTable / printEventsBodyTable
   } else {
       $this->printTable($v);  // renderiza <table> aninhada recursivamente
   }
 ```

 Isso gerava `<table>` dentro de `<table>` com as estruturas dos objetos, produzindo saída com arrays visíveis nas células do Excel.

 ### Solução

 Hook no pipeline de exportação, inteiramente contido no módulo ProjectMonitoring, sem alterar arquivos core. Intercepta os hooks api.response(html/excel).array(Entities):before e formata os campos complexos como texto legível antes da renderização:

 workplanSnapshot → resumo em português:

 ```
   3 meta(s) — 1 concluída, 2 em andamento (8 entrega(s) total)
 ```

 goalStatuses → mesmo formato já usado no módulo de planilhas:

 ```
   2/5 concluídas
 ```

 workplanProxy → JSON string (estrutura muito complexa para sumarizar)

 ### Como o hook funciona

 O sistema de hooks do Mapas (applyBoundTo) passa argumentos por referência via call_user_func_array. Quando o hook modifica $hook_data['data'], o array original usado pelo renderizador também é afetado (PHP copy-on-write — ambos apontam para o mesmo zval). Ao substituir os objetos complexos por strings antes da renderização, o printBodyTable trata os valores como strings comuns, exibindo-os diretamente na célula.

 ### Antes e depois

 ```
┌──────────────────┬─────────────────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
 │                  │ Antes                                                       │ Depois                                                       │
 ├──────────────────┼─────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
 │ workplanSnapshot │ <table><tr><th>goals</th><td><table>... (tabelas aninhadas) │ 3 meta(s) — 1 concluída, 2 em andamento (8 entrega(s) total) │
 ├──────────────────┼─────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
 │ goalStatuses     │ [object Object] ou tabela aninhada                          │ 2/5 concluídas                                               │
 ├──────────────────┼─────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
 │ workplanProxy    │ Tabela aninhada com dezenas de rows                         │ {"goals":{...},"deliveries":{...}} (JSON)                    │
 └──────────────────┴─────────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```