### PR TITLE
#9518 Fix: corrige exibição do detalhamento para avaliador do recurso

### DIFF
--- a/src/modules/Opportunities/components/registration-results/script.js
+++ b/src/modules/Opportunities/components/registration-results/script.js
@@ -51,7 +51,7 @@ app.component('registration-results', {
         },
 
         modalTitle() {
-            return this.registration.opportunity.status === -20 ? 
+            return this.registration?.opportunity?.status === -20 ?
                 `${this.text('Detalhamento do recurso para ')} ${this.phase.name} - ${this.registration.number}` :
                 `${this.phase.name} - ${this.registration.number}`;
         },


### PR DESCRIPTION
## Resumo
Corrige erro ao abrir a tela de avaliação de recurso para avaliadores sem permissão de controle.
## Alteração
Ajusta o acesso ao status da oportunidade no título do modal de detalhamento, evitando erro quando a inscrição vem com dados reduzidos.
## Referência
Alteração já implementada pela comunidade no repositório `mapasculturais-minc`.
Commit de referência: `deadb60f069af267e3aa2f03a920f372e7f83a1a`